### PR TITLE
Add log discriminator to separate log file when modernized plugin

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/ConsoleLogFilter.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/ConsoleLogFilter.java
@@ -6,10 +6,13 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.spi.FilterReply;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 
-public class ApplicationLogFilter extends ThresholdFilter {
+public class ConsoleLogFilter extends ThresholdFilter {
 
     @Override
     public FilterReply decide(ILoggingEvent event) {
+        if (event.getMarkerList() != null && !event.getMarkerList().isEmpty()) {
+            return FilterReply.DENY;
+        }
         if (Config.DEBUG) {
             setLevel(Level.DEBUG.levelStr);
         }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminator.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminator.java
@@ -1,0 +1,26 @@
+package io.jenkins.tools.pluginmodernizer.cli;
+
+import java.util.List;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.sift.AbstractDiscriminator;
+import org.slf4j.Marker;
+
+public class PluginLoggerDiscriminator extends AbstractDiscriminator<ILoggingEvent> {
+
+    @Override
+    public String getDiscriminatingValue(ILoggingEvent iLoggingEvent) {
+        List<Marker> markers = iLoggingEvent.getMarkerList();
+        if (markers == null || markers.isEmpty()) {
+            return "modernizer";
+        }
+        final Marker marker = markers.get(0);
+        return marker.getName();
+    }
+
+    @Override
+    public String getKey() {
+        return "filename";
+    }
+
+}

--- a/plugin-modernizer-cli/src/main/resources/logback.xml
+++ b/plugin-modernizer-cli/src/main/resources/logback.xml
@@ -7,30 +7,36 @@
         <resetJUL>true</resetJUL>
     </contextListener>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="io.jenkins.tools.pluginmodernizer.cli.ApplicationLogFilter" >
+        <filter class="io.jenkins.tools.pluginmodernizer.cli.ConsoleLogFilter" >
             <level>INFO</level>
         </filter>
         <encoder>
             <pattern>%msg %n</pattern>
         </encoder>
     </appender>
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>TRACE</level>
-        </filter>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z', 'UTC'} [%level] [Thread=%t] - %logger{36} # %msg %n</pattern>
-        </encoder>
-        <file>logs/modernizer.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/modernizer-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
-            <maxFileSize>5MB</maxFileSize>
-        </rollingPolicy>
+    <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <discriminator class="io.jenkins.tools.pluginmodernizer.cli.PluginLoggerDiscriminator"></discriminator>
+        <sift>
+            <appender name="FILE-${filename}" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                    <level>TRACE</level>
+                </filter>
+                <encoder>
+                    <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z', 'UTC'} [%level] [Thread=%t] - %logger{36} # %msg %n</pattern>
+                </encoder>
+                <file>logs/${filename}.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                    <fileNamePattern>logs/${filename}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                    <maxHistory>7</maxHistory>
+                    <maxFileSize>5MB</maxFileSize>
+                </rollingPolicy>
+            </appender>
+        </sift>
     </appender>
     <root>
         <appender-ref ref="CONSOLE" />
-        <appender-ref ref="FILE" />
+        <appender-ref ref="SIFT" />
     </root>
     <logger name="io.jenkins.tools.pluginmodernizer" level="TRACE" />
+    <logger name="java.lang.ProcessBuilder" level="WARN" />
 </configuration>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -22,10 +22,15 @@ public class PluginModernizer {
 
     public void start() {
         String projectRoot = System.getProperty("user.dir");
+        LOG.info("Plugins: {}", config.getPlugins());
+        LOG.info("Recipes: {}", config.getRecipes());
+        LOG.debug("Cache Path: {}", config.getCachePath());
         for (String plugin : config.getPlugins()) {
             String pluginPath = projectRoot + "/test-plugins/" + plugin;
-            mavenInvoker.invokeGoal(pluginPath, "clean");
-            mavenInvoker.invokeRewrite(pluginPath);
+            LOG.info("Invoking clean phase for plugin: {}", plugin);
+            mavenInvoker.invokeGoal(plugin, pluginPath, "clean");
+            LOG.info("Invoking rewrite plugin for plugin: {}", plugin);
+            mavenInvoker.invokeRewrite(plugin, pluginPath);
         }
     }
 


### PR DESCRIPTION
Redirect all build logs to specific logger to avoid polluting the console logs and will simplify debugging, also ensure batch mode and remove transfer progress

Will create for example one log file per plugin and one for tool

![Screenshot from 2024-06-22 10-48-47](https://github.com/jenkinsci/plugin-modernizer-tool/assets/825750/911f0d6a-3080-4cfd-8376-191a655a6b3d)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
