### PR TITLE
Remove unused config and override maven home and cache on CLI

### DIFF
--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -12,7 +12,6 @@
     <artifactId>plugin-modernizer-cli</artifactId>
     <name>Plugin Modernizer CLI Interface</name>
 
-
     <dependencies>
         <dependency>
             <groupId>io.jenkins.plugin-modernizer</groupId>
@@ -44,10 +43,54 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>apache-maven</artifactId>
+            <scope>test</scope>
+            <classifier>bin</classifier>
+            <type>zip</type>
+            <version>${maven.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <MAVEN_HOME>${project.build.directory}/apache-maven-${maven.version}</MAVEN_HOME>
+                        <M2_HOME>${project.build.directory}/apache-maven-${maven.version}</M2_HOME>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.maven</groupId>
+                                    <artifactId>apache-maven</artifactId>
+                                    <classifier>bin</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <!-- version specified in parent pom -->

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -1,8 +1,10 @@
 package io.jenkins.tools.pluginmodernizer.cli;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,12 @@ public class Main implements Runnable {
     @Option(names = {"-d", "--debug"}, description = "Enable debug logging.")
     public boolean debug;
 
+    @Option(names = {"-c", "--cache-path"}, description = "Path to the cache directory.")
+    public Path cachePath = Settings.DEFAULT_CACHE_PATH;
+
+    @Option(names = {"-m", "--maven-home"}, description = "Path to the Maven Home directory.")
+    public Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
+
     public Config setup() {
         Config.DEBUG = debug;
         return Config.builder()
@@ -44,6 +52,8 @@ public class Main implements Runnable {
                 .withPlugins(plugins)
                 .withRecipes(recipes)
                 .withDryRun(dryRun)
+                .withCachePath(cachePath)
+                .withMavenHome(mavenHome)
                 .build();
     }
 

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
@@ -3,6 +3,8 @@ package io.jenkins.tools.pluginmodernizer.cli;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,14 @@ public class MainTest {
     @Test
     public void testMissingRecipesArgument() {
         String[] args = {"-p", "plugin1,plugin2"};
+        Main main = new Main();
+        int exitCode = new CommandLine(main).execute(args);
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+    }
+
+    @Test
+    public void testMavenHome() throws IOException {
+        String[] args = {"--maven-home", Files.createTempDirectory("unsued").toString()};
         Main main = new Main();
         int exitCode = new CommandLine(main).execute(args);
         assertEquals(CommandLine.ExitCode.USAGE, exitCode);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -10,17 +10,15 @@ public class Config {
     private final List<String> plugins;
     private final List<String> recipes;
     private final Path cachePath;
-    private final String mavenHome;
-    private final String mavenRewritePluginVersion;
+    private final Path mavenHome;
     private final boolean dryRun;
 
-    private Config(String version, List<String> plugins, List<String> recipes, Path cachePath, String mavenHome, String mavenRewritePluginVersion, boolean dryRun) {
+    private Config(String version, List<String> plugins, List<String> recipes, Path cachePath, Path mavenHome, boolean dryRun) {
         this.version = version;
         this.plugins = plugins;
         this.recipes = recipes;
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
-        this.mavenRewritePluginVersion = mavenRewritePluginVersion;
         this.dryRun = dryRun;
     }
 
@@ -40,12 +38,8 @@ public class Config {
         return cachePath;
     }
 
-    public String getMavenHome() {
+    public Path getMavenHome() {
         return mavenHome;
-    }
-
-    public String getMavenPluginVersion() {
-        return mavenRewritePluginVersion;
     }
 
     public boolean isDryRun() {
@@ -61,8 +55,7 @@ public class Config {
         private List<String> plugins;
         private List<String> recipes;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
-        private String mavenHome = Settings.MAVEN_HOME_PATH;
-        private String mavenRewritePluginVersion = Settings.MAVEN_REWRITE_PLUGIN_VERSION;
+        private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
         private boolean dryRun = false;
 
         public Builder withVersion(String version) {
@@ -81,17 +74,16 @@ public class Config {
         }
 
         public Builder withCachePath(Path cachePath) {
-            this.cachePath = cachePath;
+            if (cachePath != null) {
+                this.cachePath = cachePath;
+            }
             return this;
         }
 
-        public Builder withMavenHome(String mavenHome) {
-            this.mavenHome = mavenHome;
-            return this;
-        }
-
-        public Builder withMavenPluginVersion(String mavenPluginVersion) {
-            this.mavenRewritePluginVersion = mavenPluginVersion;
+        public Builder withMavenHome(Path mavenHome) {
+            if (mavenHome != null) {
+                this.mavenHome = mavenHome;
+            }
             return this;
         }
 
@@ -101,7 +93,7 @@ public class Config {
         }
 
         public Config build() {
-            return new Config(version, plugins, recipes, cachePath, mavenHome, mavenRewritePluginVersion, dryRun);
+            return new Config(version, plugins, recipes, cachePath, mavenHome, dryRun);
         }
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -7,7 +7,7 @@ public class Settings {
 
     public static final Path DEFAULT_CACHE_PATH;
 
-    public static final String MAVEN_HOME_PATH;
+    public static final Path DEFAULT_MAVEN_HOME;
 
     public static final String MAVEN_REWRITE_PLUGIN_VERSION = "5.34.1";
 
@@ -23,14 +23,14 @@ public class Settings {
         } else {
             DEFAULT_CACHE_PATH = Paths.get(cacheDirFromEnv);
         }
-        MAVEN_HOME_PATH = getMavenHomePath();
+        DEFAULT_MAVEN_HOME = getDefaultMavenHome();
     }
 
-    private static String getMavenHomePath() {
+    private static Path getDefaultMavenHome() {
         String mavenHome = System.getenv("MAVEN_HOME");
         if (mavenHome == null) {
             mavenHome = System.getenv("M2_HOME");
         }
-        return mavenHome;
+        return Path.of(mavenHome);
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -31,6 +31,9 @@ public class Settings {
         if (mavenHome == null) {
             mavenHome = System.getenv("M2_HOME");
         }
+        if (mavenHome == null) {
+            return null;
+        }
         return Path.of(mavenHome);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <asm.version>9.7</asm.version>
         <gson.version>2.11.0</gson.version>
         <dataformat.version>2.16.1</dataformat.version>
+        <maven.version>3.9.8</maven.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
I don't think we need to change the mavenRewritePluginVersion at runtime. Can be just a constant on the `Settings`

But passing the `--maven-home` sounds more useful on environment that doesn't declare (M2_HOME or MAVEN_HOME)

Also use `Path`instead of using `String` for paths

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
