### PR TITLE
Reference `AddCodeOwner`existing recipe

### DIFF
--- a/plugin-modernizer-core/src/main/resources/recipe_data.yaml
+++ b/plugin-modernizer-core/src/main/resources/recipe_data.yaml
@@ -5,3 +5,6 @@ recipes:
   AddPluginsBom:
     fqcn: "org.openrewrite.jenkins.AddPluginsBom"
     artifactCoordinates: "org.openrewrite.recipe:rewrite-jenkins:0.8.1"
+  AddCodeOwner:
+    fqcn: "org.openrewrite.jenkins.github.AddTeamToCodeowners"
+    artifactCoordinates: "org.openrewrite.recipe:rewrite-jenkins:0.8.1"


### PR DESCRIPTION
After seeing 

![Screenshot from 2024-06-23 11-47-16](https://github.com/jenkinsci/plugin-modernizer-tool/assets/825750/5f7014a1-edae-4ef4-a3c0-0464689cce31)

On one of my plugin (https://plugins.jenkins.io/extension-filter/healthscore/) I wanted to test running such recipe with the CLI.

For now the PHS redirect just to the OpenRewrite website. Perhaps for GSoC 2024 we could just have a one-line instruction on how to fix it (that the developer will run on it machine). I don't expect we have time to so something more automated directly via some kind of button or auto-fix

Detailed instruction also on https://github.com/jenkinsci/extension-filter-plugin/pull/89

But given here

For now it's quite manual but works 

```bash
mvn clean install 
git clone git@github.com:jonesbusy/extension-filter-plugin.git test-plugins/extension-filter-plugin
java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins extension-filter-plugin --recipes AddCodeOwner
git -C test-plugins/extension-filter-plugin checkout -b feature/code-owner
git -C test-plugins/extension-filter-plugin add .
git -C test-plugins/extension-filter-plugin commit -m "Add codeowner"
git -C test-plugins/extension-filter-plugin push origin feature/code-owner 
```


### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

