### PR TITLE
Extract maven rewrite plugin to properties from pom

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -70,6 +70,7 @@
                 <directory>src/main/resources</directory>
                 <includes>
                     <include>recipe_data.yaml</include>
+                    <include>versions.properties</include>
                 </includes>
                 <filtering>true</filtering>
             </resource>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -1,15 +1,25 @@
 package io.jenkins.tools.pluginmodernizer.core.config;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Properties;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Settings {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Settings.class);
 
     public static final Path DEFAULT_CACHE_PATH;
 
     public static final Path DEFAULT_MAVEN_HOME;
 
-    public static final String MAVEN_REWRITE_PLUGIN_VERSION = "5.34.1";
+    public static final String MAVEN_REWRITE_PLUGIN_VERSION;
 
     public static final String RECIPE_DATA_YAML_PATH = "recipe_data.yaml";
 
@@ -26,6 +36,7 @@ public class Settings {
             DEFAULT_CACHE_PATH = Paths.get(cacheDirFromEnv);
         }
         DEFAULT_MAVEN_HOME = getDefaultMavenHome();
+        MAVEN_REWRITE_PLUGIN_VERSION = getRewritePluginVersion();
     }
 
     private static Path getDefaultMavenHome() {
@@ -37,5 +48,38 @@ public class Settings {
             return null;
         }
         return Path.of(mavenHome);
+    }
+
+    private static @Nullable String getRewritePluginVersion() {
+        return readProperty("openrewrite.maven.plugin.version", "versions.properties");
+    }
+
+    /**
+     * Read a property from a resource file.
+     * @param key The key to read
+     * @param resource The resource file to read from
+     * @return The value of the property or null if it could not be read
+     */
+    private static @Nullable String readProperty(@NonNull final String key, @NonNull final String resource) {
+        Properties properties = new Properties();
+        try (InputStream input = Settings.class.getClassLoader().getResourceAsStream(resource)) {
+            if (input == null) {
+                LOG.error("Error reading {} from settings", resource);
+                throw new IOException(String.format("Unable to to load `%s`", resource));
+            }
+            properties.load(input);
+        }
+        catch (IOException e) {
+            LOG.error("Error reading key {} from {}", key, resource, e);
+            return null;
+        }
+
+        String value = properties.getProperty(key);
+        if (value == null || value.isEmpty()) {
+            LOG.error(String.format("Unable to read `%s` from `%s`", key, resource));
+            return null;
+        }
+
+        return value.trim();
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -38,9 +38,7 @@ public class MavenInvoker {
     }
 
     public void invokeGoal(String plugin, String pluginPath, String goal) {
-        List<String> goals = new ArrayList<>();
-        goals.add(goal);
-        invokeGoals(plugin, pluginPath, goals);
+        invokeGoals(plugin, pluginPath, List.of(goal));
     }
 
     public void invokeRewrite(String plugin, String pluginPath) {
@@ -58,9 +56,8 @@ public class MavenInvoker {
 
     private List<String> createGoalsList() throws IOException {
         List<String> goals = new ArrayList<>();
-        String mavenPluginVersion = Settings.MAVEN_REWRITE_PLUGIN_VERSION;
         String mode = config.isDryRun() ? "dryRun" : "run";
-        goals.add("org.openrewrite.maven:rewrite-maven-plugin:" + mavenPluginVersion + ":" + mode);
+        goals.add("org.openrewrite.maven:rewrite-maven-plugin:" + Settings.MAVEN_REWRITE_PLUGIN_VERSION + ":" + mode);
 
         try (InputStream inputStream = getClass().getResourceAsStream("/" + Settings.RECIPE_DATA_YAML_PATH)) {
             ArrayNode recipesNode = (ArrayNode) objectMapper.readTree(inputStream);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -1,10 +1,13 @@
 package io.jenkins.tools.pluginmodernizer.core.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings(value = "CRLF_INJECTION_LOGS", justification = "safe because versions from pom.xml")
 public class PluginModernizer {
 
     private static final Logger LOG = LoggerFactory.getLogger(PluginModernizer.class);
@@ -25,6 +28,8 @@ public class PluginModernizer {
         LOG.info("Plugins: {}", config.getPlugins());
         LOG.info("Recipes: {}", config.getRecipes());
         LOG.debug("Cache Path: {}", config.getCachePath());
+        LOG.debug("Dry Run: {}", config.isDryRun());
+        LOG.debug("Maven rewrite plugin version: {}", Settings.MAVEN_REWRITE_PLUGIN_VERSION);
         for (String plugin : config.getPlugins()) {
             String pluginPath = projectRoot + "/test-plugins/" + plugin;
             LOG.info("Invoking clean phase for plugin: {}", plugin);

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -1,0 +1,1 @@
+openrewrite.maven.plugin.version = ${openrewrite.maven.plugin.version}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 
         <!-- Version -->
         <openrewrite.bom.version>2.13.2</openrewrite.bom.version>
+        <openrewrite.maven.plugin.version>5.34.1</openrewrite.maven.plugin.version>
         <openrewrite.jenkins.version>0.8.1</openrewrite.jenkins.version>
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.5.6</logback.version>
@@ -163,6 +164,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>${openrewrite.maven.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Instead of hard-coding the version into settings use maven filtering and property to get the version of the rewrite plugin

This will also allow dependabot to update it

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
