### PR TITLE
Use RecipeDescriptor instead of raw Jackson

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -8,10 +8,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -33,7 +32,6 @@ import org.slf4j.MarkerFactory;
 public class MavenInvoker {
 
     private static final Logger LOG = LoggerFactory.getLogger(MavenInvoker.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
 
     private final Config config;
 
@@ -103,29 +101,19 @@ public class MavenInvoker {
     }
 
     private List<String> getActiveRecipes(List<String> recipes, List<RecipeDescriptor> recipeDescriptors) {
-        List<String> activeRecipes = new ArrayList<>();
-        for (String recipe : recipes) {
-            for (RecipeDescriptor recipeDescriptor : recipeDescriptors) {
-                if (recipeDescriptor.name().equals(recipe)) {
-                    activeRecipes.add(recipeDescriptor.fqcn());
-                    break;
-                }
-            }
-        }
-        return activeRecipes;
+        return recipes.stream()
+                .flatMap(recipe -> recipeDescriptors.stream()
+                        .filter(descriptor -> descriptor.name().equals(recipe))
+                        .map(RecipeDescriptor::fqcn))
+                .collect(Collectors.toList());
     }
 
     private List<String> getRecipeArtifactCoordinates(List<String> recipes, List<RecipeDescriptor> recipeDescriptors) {
-        List<String> recipeArtifactCoordinates = new ArrayList<>();
-        for (String recipe : recipes) {
-            for (RecipeDescriptor recipeDescriptor : recipeDescriptors) {
-                if (recipeDescriptor.name().equals(recipe)) {
-                    recipeArtifactCoordinates.add(recipeDescriptor.artifactCoordinates());
-                    break;
-                }
-            }
-        }
-        return recipeArtifactCoordinates;
+        return recipes.stream()
+                .flatMap(recipe -> recipeDescriptors.stream()
+                        .filter(descriptor -> descriptor.name().equals(recipe))
+                        .map(RecipeDescriptor::artifactCoordinates))
+                .collect(Collectors.toList());
     }
 
     private void invokeGoals(String plugin, String pluginPath, List<String> goals) {


### PR DESCRIPTION
resolves this [comment](https://github.com/jenkinsci/plugin-modernizer-tool/pull/46#discussion_r1651989958)

Uses Recipe Descriptor instead of raw Jackson types

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
