### PR TITLE
Reduce some debug logs

### DIFF
--- a/plugin-modernizer-cli/src/main/resources/logback.xml
+++ b/plugin-modernizer-cli/src/main/resources/logback.xml
@@ -38,5 +38,7 @@
         <appender-ref ref="SIFT" />
     </root>
     <logger name="io.jenkins.tools.pluginmodernizer" level="TRACE" />
+    <logger name="jdk.event.security" level="INFO" />
     <logger name="java.lang.ProcessBuilder" level="WARN" />
+    <logger name="sun.net.www.protocol.http" level="INFO" />
 </configuration>


### PR DESCRIPTION
Since https://github.com/jenkinsci/plugin-modernizer-tool/pull/75 it adds some noise on debug logs (like SSL connection) that is not relevant even in debug mode

Reduce logger for `jdk.event.security` and `sun.net.www.protocol.http`

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
