### PR TITLE
Pass GH owner from CLI (in case token as access to other organisation

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -37,6 +37,9 @@ public class Main implements Runnable {
     @Option(names = {"-r", "--recipes"}, required = true, description = "List of Recipes to be applied.", split = ",", parameterConsumer = CommaSeparatedParameterConsumer.class)
     private List<String> recipes;
 
+    @Option(names = {"-g", "--github-owner"}, description = "GitHub owner for forked repositories (only username supported for now)")
+    private String githubUsername = Settings.GITHUB_USERNAME;
+
     @Option(names = {"-n", "--dry-run"}, description = "Perform a dry run without making any changes.")
     public boolean dryRun;
 
@@ -56,6 +59,7 @@ public class Main implements Runnable {
         Config.DEBUG = debug;
         return Config.builder()
                 .withVersion(getVersion())
+                .withGitHubUsername(githubUsername)
                 .withPlugins(plugins)
                 .withRecipes(recipes)
                 .withDryRun(dryRun)

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -12,9 +12,11 @@ public class Config {
     private final Path cachePath;
     private final Path mavenHome;
     private final boolean dryRun;
+    private final String githubUsername;
 
-    private Config(String version, List<String> plugins, List<String> recipes, Path cachePath, Path mavenHome, boolean dryRun) {
+    private Config(String version, String githubUsername, List<String> plugins, List<String> recipes, Path cachePath, Path mavenHome, boolean dryRun) {
         this.version = version;
+        this.githubUsername = githubUsername;
         this.plugins = plugins;
         this.recipes = recipes;
         this.cachePath = cachePath;
@@ -24,6 +26,10 @@ public class Config {
 
     public String getVersion() {
         return version;
+    }
+
+    public String getGithubUsername() {
+        return githubUsername;
     }
 
     public List<String> getPlugins() {
@@ -52,6 +58,7 @@ public class Config {
 
     public static class Builder {
         private String version;
+        private String githubUsername = Settings.GITHUB_USERNAME;
         private List<String> plugins;
         private List<String> recipes;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
@@ -60,6 +67,11 @@ public class Config {
 
         public Builder withVersion(String version) {
             this.version = version;
+            return this;
+        }
+
+        public Builder withGitHubUsername(String githubUsername) {
+            this.githubUsername = githubUsername;
             return this;
         }
 
@@ -93,7 +105,7 @@ public class Config {
         }
 
         public Config build() {
-            return new Config(version, plugins, recipes, cachePath, mavenHome, dryRun);
+            return new Config(version, githubUsername, plugins, recipes, cachePath, mavenHome, dryRun);
         }
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -69,11 +69,19 @@ public class Settings {
     }
 
     private static String getGithubToken() {
-        return System.getenv("GITHUB_TOKEN");
+        String token = System.getenv("GH_TOKEN");
+        if (token == null) {
+            token = System.getenv("GITHUB_TOKEN");
+        }
+        return token;
     }
 
     private static String getGithubUsername() {
-        return System.getenv("GITHUB_USERNAME");
+        String username = System.getenv("GH_USERNAME");
+        if (username == null) {
+            username = System.getenv("GITHUB_USERNAME");
+        }
+        return username;
     }
 
     private static String getTestPluginsDirectory() {


### PR DESCRIPTION
In a short future we should also support forking to other organisation.

For example I have the organisation `jonesbusy-automation` and I cannot use it yet for such automation

Also support `GH_TOKEN` which is also used by the gh client https://cli.github.com/manual/gh_help_environment so try to have the same order to lookup for the token

### Testing done

Interactive tests only

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
