### PR TITLE
Fetch SCM URL from UC

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -83,6 +83,7 @@
                 <includes>
                     <include>recipe_data.yaml</include>
                     <include>versions.properties</include>
+                    <include>update_center.properties</include>
                 </includes>
                 <filtering>true</filtering>
             </resource>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -32,6 +32,8 @@ public class Settings {
 
     public static final String RECIPE_DATA_YAML_PATH = "recipe_data.yaml";
 
+    public static final String UPDATE_CENTER_URL = "https://updates.jenkins.io/current/update-center.actual.json";
+
     public static final ComparableVersion MAVEN_MINIMAL_VERSION = new ComparableVersion("3.9.7");
 
     static {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -28,7 +28,7 @@ public class Settings {
 
     public static final String TEST_PLUGINS_DIRECTORY;
 
-    public static final String ORGANIZATION = "jenkinsci";
+    public static final String ORGANIZATION = "sridamul";
 
     public static final String RECIPE_DATA_YAML_PATH = "recipe_data.yaml";
 
@@ -72,7 +72,11 @@ public class Settings {
     }
 
     private static @Nullable String getUpdateCenterUrl() {
-        return readProperty("update.center.url", "update_center.properties");
+        String url = System.getenv("JENKINS_UC");
+        if(url == null) {
+            url = readProperty("update.center.url", "update_center.properties");
+        }
+        return url;
     }
 
     private static String getGithubToken() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -32,7 +32,7 @@ public class Settings {
 
     public static final String RECIPE_DATA_YAML_PATH = "recipe_data.yaml";
 
-    public static final String UPDATE_CENTER_URL = "https://updates.jenkins.io/current/update-center.actual.json";
+    public static final String UPDATE_CENTER_URL;
 
     public static final ComparableVersion MAVEN_MINIMAL_VERSION = new ComparableVersion("3.9.7");
 
@@ -50,6 +50,7 @@ public class Settings {
         }
         DEFAULT_MAVEN_HOME = getDefaultMavenHome();
         MAVEN_REWRITE_PLUGIN_VERSION = getRewritePluginVersion();
+        UPDATE_CENTER_URL = getUpdateCenterUrl();
         GITHUB_TOKEN = getGithubToken();
         GITHUB_OWNER = getGithubOwner();
         TEST_PLUGINS_DIRECTORY = getTestPluginsDirectory();
@@ -68,6 +69,10 @@ public class Settings {
 
     private static @Nullable String getRewritePluginVersion() {
         return readProperty("openrewrite.maven.plugin.version", "versions.properties");
+    }
+
+    private static @Nullable String getUpdateCenterUrl() {
+        return readProperty("update.center.url", "update_center.properties");
     }
 
     private static String getGithubToken() {
@@ -101,7 +106,7 @@ public class Settings {
         try (InputStream input = Settings.class.getClassLoader().getResourceAsStream(resource)) {
             if (input == null) {
                 LOG.error("Error reading {} from settings", resource);
-                throw new IOException(String.format("Unable to to load `%s`", resource));
+                throw new IOException(String.format("Unable to load `%s`", resource));
             }
             properties.load(input);
         }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -28,7 +28,7 @@ public class Settings {
 
     public static final String TEST_PLUGINS_DIRECTORY;
 
-    public static final String ORGANIZATION = "sridamul";
+    public static final String ORGANIZATION = "jenkinsci";
 
     public static final String RECIPE_DATA_YAML_PATH = "recipe_data.yaml";
 
@@ -73,7 +73,7 @@ public class Settings {
 
     private static @Nullable String getUpdateCenterUrl() {
         String url = System.getenv("JENKINS_UC");
-        if(url == null) {
+        if (url == null) {
             url = readProperty("update.center.url", "update_center.properties");
         }
         return url;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
@@ -56,8 +55,7 @@ public class GHService {
     public void forkCloneAndCreateBranch(String pluginName, String branchName) throws IOException, GitAPIException, InterruptedException {
         Path pluginDirectory = Paths.get(Settings.TEST_PLUGINS_DIRECTORY, pluginName);
 
-        JsonNode jsonNode = JenkinsPluginInfo.getCachedJsonNode(config.getCachePath());
-        repoName = JenkinsPluginInfo.extractRepoName(pluginName, jsonNode);
+        repoName = JenkinsPluginInfo.extractRepoName(pluginName, config.getCachePath());
 
         GitHub github = GitHub.connectUsingOAuth(Settings.GITHUB_TOKEN);
         GHRepository originalRepo = github.getRepository(Settings.ORGANIZATION + "/" + repoName);
@@ -105,7 +103,6 @@ public class GHService {
     }
 
     private void forkRepository(GHRepository originalRepo, GHOrganization organization) throws IOException, InterruptedException {
-        LOG.info("Forking the repository to organization...");
         if (organization == null) {
             LOG.info("Forking the repository to personal account...");
             originalRepo.fork();

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/UpdateCenterData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/UpdateCenterData.java
@@ -1,0 +1,42 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class UpdateCenterData {
+    private final JsonNode jsonNode;
+
+    public UpdateCenterData(JsonNode jsonNode) {
+        this.jsonNode = Objects.requireNonNull(jsonNode, "jsonNode must not be null");
+    }
+
+    public JsonNode getPlugin(String pluginName) {
+        JsonNode plugins = jsonNode.get("plugins");
+        if (plugins == null || !plugins.has(pluginName)) {
+            throw new IllegalArgumentException("Plugin not found in update center: " + pluginName);
+        }
+        return plugins.get(pluginName);
+    }
+
+    public String getScmUrl(String pluginName) {
+        JsonNode pluginInfo = getPlugin(pluginName);
+        JsonNode scmNode = pluginInfo.get("scm");
+
+        if (scmNode == null) {
+            throw new NoSuchElementException("SCM information is missing for plugin: " + pluginName);
+        }
+
+        if (scmNode.isObject()) {
+            return Optional.ofNullable(scmNode.get("url"))
+                    .map(JsonNode::asText)
+                    .orElseThrow(() -> new NoSuchElementException("SCM URL is missing for plugin: " + pluginName));
+        } else if (scmNode.isTextual()) {
+            return scmNode.asText();
+        } else {
+            throw new IllegalStateException("Unexpected type for SCM URL: " + scmNode.getNodeType());
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
@@ -1,0 +1,90 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JenkinsPluginInfo {
+    private static final Logger logger = LoggerFactory.getLogger(JenkinsPluginInfo.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static JsonNode getCachedJsonNode(Path cacheDir) throws IOException {
+        Path cacheFile = cacheDir.resolve("update-center.json");
+
+        if (!Files.exists(cacheDir)) {
+            Files.createDirectories(cacheDir);
+        }
+
+        if (Files.exists(cacheFile)) {
+            String jsonStr = new String(Files.readAllBytes(cacheFile), StandardCharsets.UTF_8);
+            return objectMapper.readTree(jsonStr);
+        } else {
+            URL apiUrl = new URL(Settings.UPDATE_CENTER_URL);
+            HttpURLConnection con = null;
+            BufferedReader in = null;
+
+            try {
+                con = (HttpURLConnection) apiUrl.openConnection();
+                con.setRequestMethod("GET");
+
+                in = new BufferedReader(new InputStreamReader(con.getInputStream(), StandardCharsets.UTF_8));
+                StringBuilder response = new StringBuilder();
+                String inputLine;
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+
+                Files.write(cacheFile, response.toString().getBytes(StandardCharsets.UTF_8));
+                return objectMapper.readTree(response.toString());
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (IOException e) {
+                        logger.error("Error closing BufferedReader: ", e);
+                    }
+                }
+                if (con != null) {
+                    con.disconnect();
+                }
+            }
+        }
+    }
+
+    public static String extractRepoName(String pluginName, JsonNode jsonNode) {
+        JsonNode plugins = jsonNode.get("plugins");
+        if (plugins == null || !plugins.has(pluginName)) {
+            throw new RuntimeException("Plugin not found in update center: " + pluginName);
+        }
+
+        JsonNode pluginInfo = plugins.get(pluginName);
+
+        JsonNode scmNode = pluginInfo.get("scm");
+        String scmUrl;
+        if (scmNode.isObject()) {
+            scmUrl = scmNode.get("url").asText();
+        } else if (scmNode.isTextual()) {
+            scmUrl = scmNode.asText();
+        } else {
+            throw new RuntimeException("Unexpected type for SCM URL: " + scmNode.getNodeType());
+        }
+
+        int lastSlashIndex = scmUrl.lastIndexOf('/');
+        if (lastSlashIndex != -1 && lastSlashIndex < scmUrl.length() - 1) {
+            return scmUrl.substring(lastSlashIndex + 1);
+        } else {
+            throw new RuntimeException("Invalid SCM URL format: " + scmUrl);
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
@@ -11,14 +11,16 @@ import java.nio.file.Path;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JenkinsPluginInfo {
-    private static final Logger logger = LoggerFactory.getLogger(JenkinsPluginInfo.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JenkinsPluginInfo.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "safe url")
     public static JsonNode getCachedJsonNode(Path cacheDir) throws IOException {
         Path cacheFile = cacheDir.resolve("update-center.json");
 
@@ -27,7 +29,7 @@ public class JenkinsPluginInfo {
         }
 
         if (Files.exists(cacheFile)) {
-            String jsonStr = new String(Files.readAllBytes(cacheFile), StandardCharsets.UTF_8);
+            String jsonStr = Files.readString(cacheFile);
             return objectMapper.readTree(jsonStr);
         } else {
             URL apiUrl = new URL(Settings.UPDATE_CENTER_URL);
@@ -45,14 +47,14 @@ public class JenkinsPluginInfo {
                     response.append(inputLine);
                 }
 
-                Files.write(cacheFile, response.toString().getBytes(StandardCharsets.UTF_8));
+                Files.writeString(cacheFile, response.toString());
                 return objectMapper.readTree(response.toString());
             } finally {
                 if (in != null) {
                     try {
                         in.close();
                     } catch (IOException e) {
-                        logger.error("Error closing BufferedReader: ", e);
+                        LOG.error("Error closing BufferedReader: ", e);
                     }
                 }
                 if (con != null) {

--- a/plugin-modernizer-core/src/main/resources/update_center.properties
+++ b/plugin-modernizer-core/src/main/resources/update_center.properties
@@ -1,0 +1,1 @@
+update.center.url=https://updates.jenkins.io/current/update-center.actual.json

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
@@ -1,13 +1,13 @@
 package io.jenkins.tools.pluginmodernizer.core.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -16,28 +16,25 @@ class JenkinsPluginInfoTest {
     @TempDir
     Path tempDir;
 
-    @Test
-    public void testGetCachedJsonNode() throws IOException {
+    @BeforeEach
+    public void setup() throws IOException {
         String jsonContent = "{\"plugins\": {\"login-theme\": {\"scm\": \"https://github.com/jenkinsci/login-theme-plugin\"}}}";
         Path cacheFile = tempDir.resolve("update-center.json");
         Files.write(cacheFile, jsonContent.getBytes());
-
-        JsonNode jsonNode = JenkinsPluginInfo.getCachedJsonNode(tempDir);
-
-        assertTrue(jsonNode.has("plugins"));
-        assertEquals("https://github.com/jenkinsci/login-theme-plugin",
-                jsonNode.get("plugins").get("login-theme").get("scm").asText());
     }
 
     @Test
-    public void testExtractRepoName() throws IOException {
-        String jsonContent = "{\"plugins\": {\"login-theme\": {\"scm\": \"https://github.com/jenkinsci/login-theme-plugin\"}}}";
-        Path cacheFile = tempDir.resolve("update-center.json");
-        Files.write(cacheFile, jsonContent.getBytes());
-
-        JsonNode jsonNode = JenkinsPluginInfo.getCachedJsonNode(tempDir);
-        String result = JenkinsPluginInfo.extractRepoName("login-theme", jsonNode);
+    public void testExtractRepoNamePresent() {
+        String result = JenkinsPluginInfo.extractRepoName("login-theme", tempDir);
         assertEquals("login-theme-plugin", result);
     }
 
+    @Test
+    public void testExtractRepoNameAbsent() {
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            JenkinsPluginInfo.extractRepoName("not-present", tempDir);
+        });
+
+        assertEquals("Plugin not found in update center: not-present", exception.getMessage());
+    }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
@@ -1,0 +1,43 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JenkinsPluginInfoTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void testGetCachedJsonNode() throws IOException {
+        String jsonContent = "{\"plugins\": {\"login-theme\": {\"scm\": \"https://github.com/jenkinsci/login-theme-plugin\"}}}";
+        Path cacheFile = tempDir.resolve("update-center.json");
+        Files.write(cacheFile, jsonContent.getBytes());
+
+        JsonNode jsonNode = JenkinsPluginInfo.getCachedJsonNode(tempDir);
+
+        assertTrue(jsonNode.has("plugins"));
+        assertEquals("https://github.com/jenkinsci/login-theme-plugin",
+                jsonNode.get("plugins").get("login-theme").get("scm").asText());
+    }
+
+    @Test
+    public void testExtractRepoName() throws IOException {
+        String jsonContent = "{\"plugins\": {\"login-theme\": {\"scm\": \"https://github.com/jenkinsci/login-theme-plugin\"}}}";
+        Path cacheFile = tempDir.resolve("update-center.json");
+        Files.write(cacheFile, jsonContent.getBytes());
+
+        JsonNode jsonNode = JenkinsPluginInfo.getCachedJsonNode(tempDir);
+        String result = JenkinsPluginInfo.extractRepoName("login-theme", jsonNode);
+        assertEquals("login-theme-plugin", result);
+    }
+
+}


### PR DESCRIPTION
Initially, Repository name is used as in -p option
For EG: `42crunch-security-audit-plugin` (which is a repo name) instead of `42crunch-security-audit` (which is the plugin name)

Now, we can use the plugin short name instead of repo name.

### Testing done
Unit Tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
Closes #97.