### PR TITLE
Show patch file path in log

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -142,14 +142,16 @@ public class GHService {
     }
 
     public void commitAndCreatePR(String pluginName, String branchName) throws IOException, GitAPIException {
+        Path pluginDirectory = Paths.get(Settings.TEST_PLUGINS_DIRECTORY, pluginName);
+
         if (config.isDryRun()) {
             LOG.info("Skipping commit and pull request creation for {}", pluginName);
+            Path patchFilePath = pluginDirectory.resolve("target/rewrite/rewrite.patch");
+            LOG.info("Patch file path: {}", patchFilePath);
             return;
         }
 
         LOG.info("Creating pull request for plugin: {}", pluginName);
-
-        Path pluginDirectory = Paths.get(Settings.TEST_PLUGINS_DIRECTORY, pluginName);
 
         commitChanges(pluginDirectory);
 


### PR DESCRIPTION
Closes #94 

Shows Patch file path in the log.
Since some patch files might be very large, it may not be advisable to display all changes in the log.

### Log
```
Starting Plugin Modernizer 
Plugins: [login-theme-plugin] 
Recipes: [AddPluginsBom] 
GitHub owner: srid3 
Forking and cloning login-theme-plugin locally 
Repository already forked to personal account srid3 
Branch already exists. Checking out the branch. 
Invoking clean phase for plugin: login-theme-plugin 
Invoking rewrite plugin for plugin: login-theme-plugin 
Skipping commit and pull request creation for login-theme-plugin 
Patch file path: C:\Users\srid0\OneDrive\Desktop\GSoC-24\plugin-modernizer-tool\test-plugins\login-theme-plugin\target\rewrite\rewrite.patch 
```

Open to other suggestions

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
~- [ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
