### PR TITLE
Add new option to fetch update center url

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -52,6 +52,9 @@ public class Main implements Runnable {
     @Option(names = {"-d", "--debug"}, description = "Enable debug logging.")
     public boolean debug;
 
+    @Option(names = "--jenkins-update-center", description = "Sets main update center; will override JENKINS_UC environment variable. If not set via CLI option or environment variable, will use default update center url")
+    public String jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
+
     @Option(names = {"-c", "--cache-path"}, description = "Path to the cache directory.")
     public Path cachePath = Settings.DEFAULT_CACHE_PATH;
 
@@ -69,6 +72,7 @@ public class Main implements Runnable {
                 .withPlugins(plugins)
                 .withRecipes(recipes)
                 .withDryRun(dryRun)
+                .withJenkinsUpdateCenter(jenkinsUpdateCenter)
                 .withCachePath(cachePath)
                 .withMavenHome(mavenHome)
                 .build();

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
@@ -141,6 +141,13 @@ public class MainTest {
     }
 
     @Test
+    public void testJenkinsUpdateCenterOption() {
+        String[] args = {"-p", "plugin1,plugin2", "-r", "recipe1,recipe2", "--jenkins-update-center", "test-url"};
+        commandLine.execute(args);
+        assertEquals("test-url", main.setup().getJenkinsUpdateCenter());
+    }
+
+    @Test
     public void testListRecipesOption() {
         String[] args = {"-l"};
         commandLine.execute(args);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -9,16 +9,18 @@ public class Config {
     private final String version;
     private final List<String> plugins;
     private final List<String> recipes;
+    private final String jenkinsUpdateCenter;
     private final Path cachePath;
     private final Path mavenHome;
     private final boolean dryRun;
     private final String githubOwner;
 
-    private Config(String version, String githubOwner, List<String> plugins, List<String> recipes, Path cachePath, Path mavenHome, boolean dryRun) {
+    private Config(String version, String githubOwner, List<String> plugins, List<String> recipes, String jenkinsUpdateCenter, Path cachePath, Path mavenHome, boolean dryRun) {
         this.version = version;
         this.githubOwner = githubOwner;
         this.plugins = plugins;
         this.recipes = recipes;
+        this.jenkinsUpdateCenter = jenkinsUpdateCenter;
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
         this.dryRun = dryRun;
@@ -38,6 +40,10 @@ public class Config {
 
     public List<String> getRecipes() {
         return recipes;
+    }
+
+    public String getJenkinsUpdateCenter() {
+        return jenkinsUpdateCenter;
     }
 
     public Path getCachePath() {
@@ -61,6 +67,7 @@ public class Config {
         private String githubOwner = Settings.GITHUB_OWNER;
         private List<String> plugins;
         private List<String> recipes;
+        private String jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
         private boolean dryRun = false;
@@ -85,6 +92,13 @@ public class Config {
             return this;
         }
 
+        public Builder withJenkinsUpdateCenter(String jenkinsUpdateCenter) {
+            if (jenkinsUpdateCenter != null) {
+                this.jenkinsUpdateCenter = jenkinsUpdateCenter;
+            }
+            return this;
+        }
+
         public Builder withCachePath(Path cachePath) {
             if (cachePath != null) {
                 this.cachePath = cachePath;
@@ -105,7 +119,7 @@ public class Config {
         }
 
         public Config build() {
-            return new Config(version, githubOwner, plugins, recipes, cachePath, mavenHome, dryRun);
+            return new Config(version, githubOwner, plugins, recipes, jenkinsUpdateCenter, cachePath, mavenHome, dryRun);
         }
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -16,6 +16,8 @@ public class Settings {
 
     private static final Logger LOG = LoggerFactory.getLogger(Settings.class);
 
+    public static final String DEFAULT_UPDATE_CENTER_URL;
+
     public static final Path DEFAULT_CACHE_PATH;
 
     public static final Path DEFAULT_MAVEN_HOME;
@@ -31,8 +33,6 @@ public class Settings {
     public static final String ORGANIZATION = "jenkinsci";
 
     public static final String RECIPE_DATA_YAML_PATH = "recipe_data.yaml";
-
-    public static final String UPDATE_CENTER_URL;
 
     public static final ComparableVersion MAVEN_MINIMAL_VERSION = new ComparableVersion("3.9.7");
 
@@ -50,7 +50,7 @@ public class Settings {
         }
         DEFAULT_MAVEN_HOME = getDefaultMavenHome();
         MAVEN_REWRITE_PLUGIN_VERSION = getRewritePluginVersion();
-        UPDATE_CENTER_URL = getUpdateCenterUrl();
+        DEFAULT_UPDATE_CENTER_URL = getUpdateCenterUrl();
         GITHUB_TOKEN = getGithubToken();
         GITHUB_OWNER = getGithubOwner();
         TEST_PLUGINS_DIRECTORY = getTestPluginsDirectory();

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -55,7 +55,7 @@ public class GHService {
     public void forkCloneAndCreateBranch(String pluginName, String branchName) throws IOException, GitAPIException, InterruptedException {
         Path pluginDirectory = Paths.get(Settings.TEST_PLUGINS_DIRECTORY, pluginName);
 
-        repoName = JenkinsPluginInfo.extractRepoName(pluginName, config.getCachePath());
+        repoName = JenkinsPluginInfo.extractRepoName(pluginName, config.getCachePath(), config.getJenkinsUpdateCenter());
 
         GitHub github = GitHub.connectUsingOAuth(Settings.GITHUB_TOKEN);
         GHRepository originalRepo = github.getRepository(Settings.ORGANIZATION + "/" + repoName);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.model.UpdateCenterData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,9 +20,9 @@ public class JenkinsPluginInfo {
     private static final Logger LOG = LoggerFactory.getLogger(JenkinsPluginInfo.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static String extractRepoName(String pluginName, Path cacheDir) {
+    public static String extractRepoName(String pluginName, Path cacheDir, String updateCenterUrl) {
         try {
-            UpdateCenterData updateCenterData = getCachedUpdateCenterData(cacheDir);
+            UpdateCenterData updateCenterData = getCachedUpdateCenterData(cacheDir, updateCenterUrl);
             String scmUrl = updateCenterData.getScmUrl(pluginName);
 
             int lastSlashIndex = scmUrl.lastIndexOf('/');
@@ -38,14 +37,14 @@ public class JenkinsPluginInfo {
         }
     }
 
-    private static UpdateCenterData getCachedUpdateCenterData(Path cacheDir) throws IOException {
+    private static UpdateCenterData getCachedUpdateCenterData(Path cacheDir, String updateCenterUrl) throws IOException {
         Path cacheFile = cacheDir.resolve("update-center.json");
 
         if (Files.exists(cacheFile)) {
             String jsonStr = Files.readString(cacheFile);
             return parseJson(jsonStr);
         } else {
-            String jsonStr = fetchUpdateCenterData();
+            String jsonStr = fetchUpdateCenterData(updateCenterUrl);
             Files.writeString(cacheFile, jsonStr);
             return parseJson(jsonStr);
         }
@@ -57,8 +56,8 @@ public class JenkinsPluginInfo {
     }
 
     @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "safe url")
-    private static String fetchUpdateCenterData() throws IOException {
-        URL apiUrl = new URL(Settings.UPDATE_CENTER_URL);
+    private static String fetchUpdateCenterData(String updateCenterUrl) throws IOException {
+        URL apiUrl = new URL(updateCenterUrl);
 
         StringBuilder response = new StringBuilder();
 

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
@@ -17,24 +17,30 @@ public class ConfigTest {
     @Test
     public void testConfigBuilderWithAllFields() {
         String version = "1.0";
+        String githubOwner = "test-owner";
         List<String> plugins = Arrays.asList("plugin1", "plugin2");
         List<String> recipes = Arrays.asList("recipe1", "recipe2");
+        String jenkinsUpdateCenter = "https://updates.jenkins.io/current/update-center.actual.json";
         Path cachePath = Paths.get("/path/to/cache");
         Path mavenHome = Paths.get("/path/to/maven");
         boolean dryRun = true;
 
         Config config = Config.builder()
                 .withVersion(version)
+                .withGitHubOwner(githubOwner)
                 .withPlugins(plugins)
                 .withRecipes(recipes)
+                .withJenkinsUpdateCenter(jenkinsUpdateCenter)
                 .withCachePath(cachePath)
                 .withMavenHome(mavenHome)
                 .withDryRun(dryRun)
                 .build();
 
         assertEquals(version, config.getVersion());
+        assertEquals(githubOwner, config.getGithubOwner());
         assertEquals(plugins, config.getPlugins());
         assertEquals(recipes, config.getRecipes());
+        assertEquals(jenkinsUpdateCenter, config.getJenkinsUpdateCenter());
         assertEquals(cachePath, config.getCachePath());
         assertEquals(mavenHome, config.getMavenHome());
         assertTrue(config.isDryRun());
@@ -47,6 +53,7 @@ public class ConfigTest {
         assertNull(config.getVersion());
         assertNull(config.getPlugins());
         assertNull(config.getRecipes());
+        assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
         assertEquals(Settings.DEFAULT_MAVEN_HOME, config.getMavenHome());
         assertFalse(config.isDryRun());
@@ -65,6 +72,7 @@ public class ConfigTest {
         assertEquals(version, config.getVersion());
         assertEquals(plugins, config.getPlugins());
         assertNull(config.getRecipes());
+        assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
         assertEquals(Settings.DEFAULT_MAVEN_HOME, config.getMavenHome());
         assertFalse(config.isDryRun());
@@ -73,6 +81,7 @@ public class ConfigTest {
     @Test
     public void testConfigBuilderWithNullValues() {
         Config config = Config.builder()
+                .withJenkinsUpdateCenter(null)
                 .withCachePath(null)
                 .withMavenHome(null)
                 .build();
@@ -80,6 +89,7 @@ public class ConfigTest {
         assertNull(config.getVersion());
         assertNull(config.getPlugins());
         assertNull(config.getRecipes());
+        assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
         assertEquals(Settings.DEFAULT_MAVEN_HOME, config.getMavenHome());
         assertFalse(config.isDryRun());

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
@@ -16,6 +16,9 @@ class JenkinsPluginInfoTest {
     @TempDir
     Path tempDir;
 
+    @TempDir
+    Path tempDir2;
+
     @BeforeEach
     public void setup() throws IOException {
         String jsonContent = "{\"plugins\": {\"login-theme\": {\"scm\": \"https://github.com/jenkinsci/login-theme-plugin\"}}}";
@@ -24,15 +27,37 @@ class JenkinsPluginInfoTest {
     }
 
     @Test
-    public void testExtractRepoNamePresent() {
-        String result = JenkinsPluginInfo.extractRepoName("login-theme", tempDir);
+    public void testExtractRepoNamePluginPresentWithoutUrl() {
+        String result = JenkinsPluginInfo.extractRepoName("login-theme", tempDir, null);
         assertEquals("login-theme-plugin", result);
     }
 
     @Test
-    public void testExtractRepoNameAbsent() {
+    public void testExtractRepoNamePluginAbsentWithoutUrl() {
         Exception exception = assertThrows(RuntimeException.class, () -> {
-            JenkinsPluginInfo.extractRepoName("not-present", tempDir);
+            JenkinsPluginInfo.extractRepoName("not-present", tempDir, null);
+        });
+
+        assertEquals("Plugin not found in update center: not-present", exception.getMessage());
+    }
+
+    @Test
+    public void testExtractRepoNamePluginPresentWithUrl() {
+        String updateCenterUrl = "https://updates.jenkins.io/current/update-center.actual.json";
+
+        String resultLoginTheme = JenkinsPluginInfo.extractRepoName("login-theme", tempDir2, updateCenterUrl);
+        assertEquals("login-theme-plugin", resultLoginTheme);
+
+        String resultJobCacher = JenkinsPluginInfo.extractRepoName("jobcacher", tempDir2, updateCenterUrl);
+        assertEquals("jobcacher-plugin", resultJobCacher);
+    }
+
+    @Test
+    public void testExtractRepoNamePluginAbsentWithUrl() {
+        String updateCenterUrl = "https://updates.jenkins.io/current/update-center.actual.json";
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            JenkinsPluginInfo.extractRepoName("not-present", tempDir2, updateCenterUrl);
         });
 
         assertEquals("Plugin not found in update center: not-present", exception.getMessage());


### PR DESCRIPTION
Closes #89 

Added new option `--jenkins-update-center` to fetch the UC url from cli. If not provided, it will use env var `JENKINS_UC`, if both are not set, then default update center url is used -> https://updates.jenkins.io/current/update-center.actual.json

### Testing done
Unit testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
~- [ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
