### PR TITLE
Process Plugins in the Order Defined in plugins.txt

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -4,8 +4,9 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
@@ -123,7 +124,8 @@ public class Main implements Runnable {
             loadedPlugins.addAll(plugins);
         }
 
-        return new ArrayList<>(new HashSet<>(loadedPlugins));
+        Set<String> uniquePlugins = new LinkedHashSet<>(loadedPlugins);
+        return new ArrayList<>(uniquePlugins);
     }
 
     @Override

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
@@ -114,6 +114,36 @@ public class MainTest {
     }
 
     @Test
+    public void testPluginFilePluginOrder() throws IOException {
+        Path pluginFile = tempDir.resolve("plugins.txt");
+        Files.write(pluginFile, List.of("plugin1", "", "plugin2", "   ", "plugin3"));
+        String[] args = {"-f", pluginFile.toString(), "-r", "recipe1,recipe2"};
+        commandLine.execute(args);
+        List<String> plugins = main.setup().getPlugins();
+        assertNotNull(plugins);
+        assertEquals(3, plugins.size());
+        assertEquals("plugin1", plugins.get(0));
+        assertEquals("plugin2", plugins.get(1));
+        assertEquals("plugin3", plugins.get(2));
+    }
+
+    @Test
+    public void testPluginFileAlongWithPluginOptionPluginOrder() throws IOException {
+        Path pluginFile = tempDir.resolve("plugins.txt");
+        Files.write(pluginFile, List.of("plugin1", "", "plugin2", "   ", "plugin3"));
+        String[] args = {"-f", pluginFile.toString(), "-r", "recipe1,recipe2", "-p", "plugin4,plugin5"};
+        commandLine.execute(args);
+        List<String> plugins = main.setup().getPlugins();
+        assertNotNull(plugins);
+        assertEquals(5, plugins.size());
+        assertEquals("plugin1", plugins.get(0));
+        assertEquals("plugin2", plugins.get(1));
+        assertEquals("plugin3", plugins.get(2));
+        assertEquals("plugin4", plugins.get(3));
+        assertEquals("plugin5", plugins.get(4));
+    }
+
+    @Test
     public void testMavenHome() throws IOException {
         String[] args = {"--maven-home", Files.createTempDirectory("unused").toString()};
         int exitCode = commandLine.execute(args);


### PR DESCRIPTION
Closes #105 
If both `-f` and `-p` options are enabled, then the plugins are processed in the order of plugin file first, followed by the plugins passed through `-p` option.
For Eg: 
plugins.txt
```
git
git-client:1.0.0
jobcacher:2.3.4
```

`java -jar /path/to/jar --plugins login-theme,jobcacher -f path/to/plugin/file --recipes AddPluginsBom -n`
would process in order of git, git-client, jobcacher, login-theme
### Testing done
Unit tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
~- [ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
