### PR TITLE
Fix jgit not closed during clone

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -135,11 +135,12 @@ public class GHService {
         String uri = "https://github.com/" + config.getGithubOwner() + "/" + repoName + ".git";
         if (!Files.exists(pluginDirectory) || !Files.isDirectory(pluginDirectory)) {
             LOG.debug("Cloning {}", pluginName);
-            Git.cloneRepository()
+            try (Git git = Git.cloneRepository()
                     .setURI(uri)
                     .setDirectory(pluginDirectory.toFile())
-                    .call();
-            LOG.debug("Cloned successfully from {}", uri);
+                    .call()) {
+                LOG.debug("Cloned successfully from {}", uri);
+            }
         } else {
             // TODO: Cleanup and fetch latest changes. Also ensure on the main branch
         }


### PR DESCRIPTION
Should fix https://github.com/jenkinsci/plugin-modernizer-tool/issues/103

Ensuring jgit is closed after clone

I'm not sure if there is other places

### Testing done

Got CredentialsProvider  when cloning many plugin.

Was not able to reproduce after this fix

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
