### PR TITLE
Exclude artifact from rewrite jenkins to test newer versions

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -56,6 +56,33 @@
     <dependency>
       <groupId>org.openrewrite.recipe</groupId>
       <artifactId>rewrite-jenkins</artifactId>
+      <!-- Allow testing more recent version of rewrite jenkins before bom is published -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.openrewrite</groupId>
+          <artifactId>rewrite-groovy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.openrewrite</groupId>
+          <artifactId>rewrite-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.openrewrite</groupId>
+          <artifactId>rewrite-java-11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.openrewrite</groupId>
+          <artifactId>rewrite-maven</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.openrewrite</groupId>
+          <artifactId>rewrite-yaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.openrewrite.recipe</groupId>
+          <artifactId>rewrite-java-dependencies</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <!-- Version -->
     <openrewrite.bom.version>2.15.0</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>5.36.0</openrewrite.maven.plugin.version>
-    <openrewrite.jenkins.version>0.8.3</openrewrite.jenkins.version>
+    <openrewrite.jenkins.version>0.9.0</openrewrite.jenkins.version>
     <slf4j.version>2.0.13</slf4j.version>
     <logback.version>1.5.6</logback.version>
     <picocli.version>4.7.6</picocli.version>


### PR DESCRIPTION
Even if bom is provided for rewrite module, it prevent testing newer version of rewrite-jenkins before the pom is published.

Was also preventing to test SNAPSHOT version when PR are merged on main but not released yet

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
