### PR TITLE
Replace org.json:json by json-api plugin

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -20,12 +20,29 @@ recipeList:
   - org.openrewrite.jenkins.github.AddTeamToCodeowners
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+description: Upgrade the parent version to latest available
+recipeList:
+  - org.openrewrite.maven.UpgradeParentVersion:
+      groupId: org.jenkins-ci.plugins
+      artifactId: plugin
+      newVersion: 4.X
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.ReplaceLibrariesWithApiPlugin
+description: Use JSON API plugin instead of direct dependency
+recipeList:
+    # More API plugin on the list
+  - io.jenkins.tools.pluginmodernizer.UseJsonApiPlugin
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UseJsonApiPlugin
 description: Use JSON API plugin instead of direct dependency
 recipeList:
   - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: json-api
+      # TODO: version from bom and filtered here ? or managed by renovate ?
       pluginVersion: 20240303-41.v94e11e6de726
       replaces:
         - groupId: org.json

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -20,10 +20,13 @@ recipeList:
   - org.openrewrite.jenkins.github.AddTeamToCodeowners
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
-description: Upgrade the parent version to latest available
+name: io.jenkins.tools.pluginmodernizer.UseJsonApiPlugin
+description: Use JSON API plugin instead of direct dependency
 recipeList:
-  - org.openrewrite.maven.UpgradeParentVersion:
-      groupId: org.jenkins-ci.plugins
-      artifactId: plugin
-      newVersion: 4.X
+  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+      pluginGroupId: io.jenkins.plugins
+      pluginArtifactId: json-api
+      pluginVersion: 20240303-41.v94e11e6de726
+      replaces:
+        - groupId: org.json
+          artifactId: json


### PR DESCRIPTION
Use existing ReplaceLibrariesWithApiPlugin

We need to think about the TODO and how to get the latest version

The `org.openrewrite.jenkins.AddPluginsBom` cleanup such version override but doesn't change if an old bom is already added on the pom.

I'm thinking to add/implement a cleanup recipe that will just remove the version override if set on the dependency management

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
