### PR TITLE
Add cleanup option to remove local data and delete forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Alternatively, you can pass the GitHub owner through the CLI option `-g` or `--g
 
 - `--skip-pull-request` (optional) Skips creating pull requests in the remote repository. Always enabled in dry-run mode.
 
+- `--clean-local-data` (optional) Deletes the local plugin directory before and after the process is completed.
+
+- `--clean-forks` (optional) Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.
+
 - `--export-datatables` or `-e`: (optional) Creates a report or summary of the changes made through OpenRewrite in CSV format. The report will be generated at `target/rewrite/datatables` inside the plugin directory.
 
 - `--debug` or `-d`: (optional) Enables debug mode.

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -78,6 +78,17 @@ public class Main implements Runnable {
     public boolean skipPullRequest;
 
     @Option(
+            names = {"--clean-local-data"},
+            description = "Remove local plugin data before and after the modernization process.")
+    public boolean removeLocalData;
+
+    @Option(
+            names = {"--clean-forks"},
+            description =
+                    "Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.")
+    public boolean removeForks;
+
+    @Option(
             names = {"-e", "--export-datatables"},
             description = "Creates a report or summary of the changes made through OpenRewrite.")
     public boolean exportDatatables;
@@ -119,6 +130,8 @@ public class Main implements Runnable {
                 .withDryRun(dryRun)
                 .withSkipPush(skipPush)
                 .withSkipPullRequest(skipPullRequest)
+                .withRemoveLocalData(removeLocalData)
+                .withRemoveForks(removeForks)
                 .withExportDatatables(exportDatatables)
                 .withJenkinsUpdateCenter(jenkinsUpdateCenter)
                 .withCachePath(cachePath)

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
@@ -143,6 +143,39 @@ public class MainTest {
     }
 
     @Test
+    public void testSkipPushOptions() throws IOException {
+        String[] args = {"-p", "plugin1,plugin2", "-r", "recipe1,recipe2", "--skip", "recipe1,recipe2", "--skip-push"};
+        commandLine.execute(args);
+        assertTrue(main.setup().isSkipPush());
+    }
+
+    @Test
+    public void testSkipPullRequestOptions() throws IOException {
+        String[] args = {
+            "-p", "plugin1,plugin2", "-r", "recipe1,recipe2", "--skip", "recipe1,recipe2", "--skip-pull-request"
+        };
+        commandLine.execute(args);
+        assertTrue(main.setup().isSkipPullRequest());
+    }
+
+    @Test
+    public void voidTestCleanLocalData() throws IOException {
+        String[] args = {
+            "-p", "plugin1,plugin2", "-r", "recipe1,recipe2", "--skip", "recipe1,recipe2", "--clean-local-data"
+        };
+        commandLine.execute(args);
+        assertTrue(main.setup().isRemoveLocalData());
+    }
+
+    @Test
+    public void voidTestCleanForks() throws IOException {
+        String[] args = {"-p", "plugin1,plugin2", "-r", "recipe1,recipe2", "--skip", "recipe1,recipe2", "--clean-forks"
+        };
+        commandLine.execute(args);
+        assertTrue(main.setup().isRemoveForks());
+    }
+
+    @Test
     public void testMavenHome() throws IOException {
         String[] args = {"--maven-home", Files.createTempDirectory("unused").toString()};
         int exitCode = commandLine.execute(args);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -16,6 +16,8 @@ public class Config {
     private final boolean dryRun;
     private final boolean skipPush;
     private final boolean skipPullRequest;
+    private final boolean removeLocalData;
+    private final boolean removeForks;
     private final boolean exportDatatables;
     private final String githubOwner;
 
@@ -30,6 +32,8 @@ public class Config {
             boolean dryRun,
             boolean skipPush,
             boolean skipPullRequest,
+            boolean removeLocalData,
+            boolean removeForks,
             boolean exportDatatables) {
         this.version = version;
         this.githubOwner = githubOwner;
@@ -41,6 +45,8 @@ public class Config {
         this.dryRun = dryRun;
         this.skipPush = skipPush;
         this.skipPullRequest = skipPullRequest;
+        this.removeLocalData = removeLocalData;
+        this.removeForks = removeForks;
         this.exportDatatables = exportDatatables;
     }
 
@@ -84,6 +90,14 @@ public class Config {
         return skipPush;
     }
 
+    public boolean isRemoveLocalData() {
+        return removeLocalData;
+    }
+
+    public boolean isRemoveForks() {
+        return removeForks;
+    }
+
     public boolean isExportDatatables() {
         return exportDatatables;
     }
@@ -104,6 +118,8 @@ public class Config {
         private boolean skipPush = false;
         private boolean skipPullRequest = false;
         private boolean exportDatatables = false;
+        public boolean removeLocalData = false;
+        public boolean removeForks = false;
 
         public Builder withVersion(String version) {
             this.version = version;
@@ -161,6 +177,16 @@ public class Config {
             return this;
         }
 
+        public Builder withRemoveLocalData(boolean removeLocalData) {
+            this.removeLocalData = removeLocalData;
+            return this;
+        }
+
+        public Builder withRemoveForks(boolean removeForks) {
+            this.removeForks = removeForks;
+            return this;
+        }
+
         public Builder withExportDatatables(boolean exportDatatables) {
             this.exportDatatables = exportDatatables;
             return this;
@@ -178,6 +204,8 @@ public class Config {
                     dryRun,
                     skipPush,
                     skipPullRequest,
+                    removeLocalData,
+                    removeForks,
                     exportDatatables);
         }
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -61,7 +61,14 @@ public class PluginModernizer {
             plugin.withRepositoryName(JenkinsPluginInfo.extractRepoName(
                     plugin.getName(), config.getCachePath(), config.getJenkinsUpdateCenter()));
 
+            if (config.isRemoveForks()) {
+                plugin.deleteFork(ghService);
+            }
             plugin.fork(ghService);
+            if (config.isRemoveLocalData()) {
+                LOG.info("Removing local data for plugin: {} at {}", plugin, plugin.getLocalRepository());
+                plugin.removeLocalData();
+            }
             plugin.fetch(ghService);
             plugin.clean(mavenInvoker);
             plugin.checkoutBranch(ghService);
@@ -69,6 +76,9 @@ public class PluginModernizer {
             plugin.commit(ghService);
             plugin.push(ghService);
             plugin.openPullRequest(ghService);
+            if (config.isRemoveForks()) {
+                plugin.deleteFork(ghService);
+            }
 
         } catch (Exception e) {
             LOG.error("Failed to process plugin: {}", plugin, e);

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
@@ -1,0 +1,171 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import io.jenkins.tools.pluginmodernizer.core.github.GHService;
+import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PluginTest {
+
+    @Mock
+    private MavenInvoker mavenInvoker;
+
+    @Mock
+    private GHService ghService;
+
+    @Test
+    public void testPluginName() {
+        Plugin plugin = Plugin.build("example");
+        assertEquals("example", plugin.getName());
+        plugin.withName("new-name");
+        assertEquals("new-name", plugin.getName());
+    }
+
+    @Test
+    public void testRepositoryName() {
+        Plugin plugin = Plugin.build("example");
+        assertNull(plugin.getRepositoryName());
+        plugin.withRepositoryName("new-repo");
+        assertEquals("new-repo", plugin.getRepositoryName());
+    }
+
+    @Test
+    public void testLocalRepository() {
+        Plugin plugin = Plugin.build("example");
+        assertEquals(
+                Path.of(Settings.TEST_PLUGINS_DIRECTORY, plugin.getName()).toString(),
+                plugin.getLocalRepository().toString());
+    }
+
+    @Test
+    public void testGetGitHubRepository() {
+        Plugin plugin = Plugin.build("example");
+        plugin.withRepositoryName("repo-name");
+        assertEquals(
+                "https://github.com/foobar/repo-name.git",
+                plugin.getGitRepositoryURI("foobar").toString());
+    }
+
+    @Test
+    public void testHasCommits() {
+        Plugin plugin = Plugin.build("example");
+        assertFalse(plugin.hasCommits());
+        plugin.withCommits();
+        assertTrue(plugin.hasCommits());
+        plugin.withoutCommits();
+        assertFalse(plugin.hasCommits());
+    }
+
+    @Test
+    public void testClean() {
+        Plugin plugin = Plugin.build("example");
+        plugin.clean(mavenInvoker);
+        verify(mavenInvoker).invokeGoal(plugin, "clean");
+        verifyNoMoreInteractions(mavenInvoker);
+    }
+
+    @Test
+    public void testRewrite() {
+        Plugin plugin = Plugin.build("example");
+        plugin.runOpenRewrite(mavenInvoker);
+        verify(mavenInvoker).invokeRewrite(plugin);
+        verifyNoMoreInteractions(mavenInvoker);
+    }
+
+    @Test
+    public void testFork() {
+        Plugin plugin = Plugin.build("example");
+        plugin.fork(ghService);
+        verify(ghService).fork(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testIsFork() {
+        Plugin plugin = Plugin.build("example");
+        plugin.isForked(ghService);
+        verify(ghService).isForked(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testDeleteFork() {
+        Plugin plugin = Plugin.build("example");
+        plugin.deleteFork(ghService);
+        verify(ghService).deleteFork(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testCheckoutBranch() {
+        Plugin plugin = Plugin.build("example");
+        plugin.checkoutBranch(ghService);
+        verify(ghService).checkoutBranch(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testCommit() {
+        Plugin plugin = Plugin.build("example");
+        plugin.commit(ghService);
+        verify(ghService).commitChanges(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testPush() {
+        Plugin plugin = Plugin.build("example");
+        plugin.push(ghService);
+        verify(ghService).pushChanges(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testOpenPullRequest() {
+        Plugin plugin = Plugin.build("example");
+        plugin.openPullRequest(ghService);
+        verify(ghService).openPullRequest(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testFetch() {
+        Plugin plugin = Plugin.build("example");
+        plugin.fetch(ghService);
+        verify(ghService).fetch(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testGetRemoteRepository() {
+        Plugin plugin = Plugin.build("example");
+        plugin.withRepositoryName("repo-name");
+        plugin.getRemoteRepository(ghService);
+        verify(ghService).getRepository(plugin);
+    }
+
+    @Test
+    public void testGetRemoteForkRepository() {
+        Plugin plugin = Plugin.build("example");
+        plugin.withRepositoryName("repo-name");
+        plugin.getRemoteForkRepository(ghService);
+        verify(ghService).getRepositoryFork(plugin);
+    }
+
+    @Test
+    public void testHasErrors() {
+        Plugin plugin = Plugin.build("example");
+        assertFalse(plugin.hasErrors());
+        plugin.addError(new Exception("error"));
+        assertTrue(plugin.hasErrors());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Add 2 options for local data and forks cleanup. Use with caution, but we will only delete forks if no open PR are open from them.

I think we should optimize to only fork when there is actual changes to be pushed.

Probably we should only change the order

- Clone/fetch always from upstream
- Create local branch
- If there is any commit fork and change the origin
- Push the branch and create PR

This PR also add some automated tests for the Plugin class

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
