### PR TITLE
Abort plugin modernization on errors and set target JVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Alternatively, you can pass the GitHub owner through the CLI option `-g` or `--g
 
 - `--maven-home` or `-m`: (optional) Path to the Maven home directory. Required if both `MAVEN_HOME` and `M2_HOME` environment variables are not set. The minimum required version is 3.9.7.
 
+- `--source-java-major-version`: (optional) Java major version to use before applying the recipes. Defaults to 8.
+
+- `--target-java-major-version`: (optional) Java major version to use to apply the recipes and the plugin after applying the recipes. Defaults to 17.
+
 - `--version` or `-v`: (optional) Displays the version of the Plugin Modernizer tool.
 
 ## Plugin Input Format

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -115,10 +115,15 @@ public class Main implements Runnable {
     public Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
 
     @Option(
-            names = {"--minimal-java-major-version"},
+            names = {"--source-java-major-version"},
             description =
-                    "Minimal Java major version to compile the plugin before attempting to modernize it for recommended Java version")
-    public int minimalJavaMajorVersion = Settings.MINIMAL_JAVA_MAJOR_VERSION;
+                    "Source Java major version to compile the plugin before attempting to modernize it for recommended Java version")
+    public int sourceJavaMajorVersion = Settings.SOURCE_JAVA_MAJOR_VERSION;
+
+    @Option(
+            names = {"--target-java-major-version"},
+            description = "Target Java major version to modernize the plugin and run recipes")
+    public int minimalJavaMajorVersion = Settings.TARGET_JAVA_MAJOR_VERSION;
 
     @Option(
             names = {"-l", "--list-recipes"},
@@ -142,7 +147,8 @@ public class Main implements Runnable {
                 .withJenkinsUpdateCenter(jenkinsUpdateCenter)
                 .withCachePath(cachePath)
                 .withMavenHome(mavenHome)
-                .withMinimalJavaMajorVersion(minimalJavaMajorVersion)
+                .withSourceJavaMajorVersion(sourceJavaMajorVersion)
+                .withTargetJavaMajorVersion(minimalJavaMajorVersion)
                 .build();
     }
 

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
@@ -228,6 +228,14 @@ public class MainTest {
     }
 
     @Test
+    public void testJdkMajorOptions() throws MalformedURLException {
+        String[] args = {"--source-java-major-version", "11", "--target-java-major-version", "21"};
+        commandLine.execute(args);
+        assertEquals(11, main.setup().getSourceJavaMajorVersion());
+        assertEquals(21, main.setup().getTargetJavaMajorVersion());
+    }
+
+    @Test
     public void testListRecipesOption() {
         String[] args = {"-l"};
         commandLine.execute(args);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -13,7 +13,8 @@ public class Config {
     private final URL jenkinsUpdateCenter;
     private final Path cachePath;
     private final Path mavenHome;
-    private final int minimalJavaMajorVersion;
+    private final int sourceJavaMajorVersion;
+    private final int targetJavaMajorVersion;
     private final boolean dryRun;
     private final boolean skipPush;
     private final boolean skipPullRequest;
@@ -30,7 +31,8 @@ public class Config {
             URL jenkinsUpdateCenter,
             Path cachePath,
             Path mavenHome,
-            int minimalJavaMajorVersion,
+            int sourceJavaMajorVersion,
+            int targetJavaMajorVersion,
             boolean dryRun,
             boolean skipPush,
             boolean skipPullRequest,
@@ -44,7 +46,8 @@ public class Config {
         this.jenkinsUpdateCenter = jenkinsUpdateCenter;
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
-        this.minimalJavaMajorVersion = minimalJavaMajorVersion;
+        this.sourceJavaMajorVersion = sourceJavaMajorVersion;
+        this.targetJavaMajorVersion = targetJavaMajorVersion;
         this.dryRun = dryRun;
         this.skipPush = skipPush;
         this.skipPullRequest = skipPullRequest;
@@ -81,8 +84,12 @@ public class Config {
         return mavenHome;
     }
 
-    public int getMinimalJavaMajorVersion() {
-        return minimalJavaMajorVersion;
+    public int getSourceJavaMajorVersion() {
+        return sourceJavaMajorVersion;
+    }
+
+    public int getTargetJavaMajorVersion() {
+        return targetJavaMajorVersion;
     }
 
     public boolean isDryRun() {
@@ -121,7 +128,8 @@ public class Config {
         private URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
-        private int minimalJavaMajorVersion = Settings.MINIMAL_JAVA_MAJOR_VERSION;
+        private int sourceJavaMajorVersion = Settings.SOURCE_JAVA_MAJOR_VERSION;
+        private int targetJavaMajorVersion = Settings.TARGET_JAVA_MAJOR_VERSION;
         private boolean dryRun = false;
         private boolean skipPush = false;
         private boolean skipPullRequest = false;
@@ -170,8 +178,13 @@ public class Config {
             return this;
         }
 
-        public Builder withMinimalJavaMajorVersion(int minimalJavaMajorVersion) {
-            this.minimalJavaMajorVersion = minimalJavaMajorVersion;
+        public Builder withSourceJavaMajorVersion(int sourceJavaMajorVersion) {
+            this.sourceJavaMajorVersion = sourceJavaMajorVersion;
+            return this;
+        }
+
+        public Builder withTargetJavaMajorVersion(int targetJavaMajorVersion) {
+            this.targetJavaMajorVersion = targetJavaMajorVersion;
             return this;
         }
 
@@ -214,7 +227,8 @@ public class Config {
                     jenkinsUpdateCenter,
                     cachePath,
                     mavenHome,
-                    minimalJavaMajorVersion,
+                    sourceJavaMajorVersion,
+                    targetJavaMajorVersion,
                     dryRun,
                     skipPush,
                     skipPullRequest,

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -48,7 +48,7 @@ public class Settings {
     public static final List<Recipe> AVAILABLE_RECIPES;
 
     // Default JDK home from sdk man
-    public static final int MINIMAL_JAVA_MAJOR_VERSION = 8;
+    public static final int SOURCE_JAVA_MAJOR_VERSION = 8;
     public static final int TARGET_JAVA_MAJOR_VERSION = 17;
 
     public static final Path DEFAULT_JAVA_8_HOME = getDefaultSdkManJava("JAVA_8_HOME");

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -150,6 +150,7 @@ public class MavenInvoker {
             handleInvocationResult(plugin, result);
         } catch (MavenInvocationException e) {
             LOG.error(plugin.getMarker(), "Maven invocation failed: ", e);
+            plugin.addError(e);
         }
     }
 
@@ -223,6 +224,8 @@ public class MavenInvoker {
             if (result.getExecutionException() != null) {
                 LOG.error(plugin.getMarker(), "Execution exception occurred: ", result.getExecutionException());
                 plugin.addError(result.getExecutionException());
+            } else {
+                plugin.addError(new MavenInvocationException("Build failed with code: " + result.getExitCode()));
             }
         }
     }


### PR DESCRIPTION
Errors were missing in some case and when maven return a non-zero status code.

Also ensure to abort the process when such error occured 

Set also the target JDK configurable to test compiling plugin with Java 21 until we have JVM auto-detection for plugin source

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
