### PR TITLE
Add executable permissions for jdk binaries

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
@@ -20,6 +20,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -254,7 +255,7 @@ public class JdkFetcher {
      */
     private void extractTarGz(Path tarGzFile, Path extractionDir) throws IOException {
         try (InputStream fileStream = Files.newInputStream(tarGzFile);
-                InputStream gzipStream = new java.util.zip.GZIPInputStream(fileStream);
+                InputStream gzipStream = new GZIPInputStream(fileStream);
                 TarArchiveInputStream tarStream = new TarArchiveInputStream(gzipStream)) {
 
             TarArchiveEntry entry;


### PR DESCRIPTION
Resolve the executable permissions after extracting the JDK

see https://cdeliveryfdn.slack.com/archives/C071YTZ807N/p1722868913559519

### Testing done
Interactive testing with Ubuntu 24.04

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
