### PR TITLE
Maven debug in debug mode

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -1,12 +1,15 @@
 package io.jenkins.tools.pluginmodernizer.core.config;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 
 public class Config {
 
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Because usage on ConsoleLogFilter")
     public static boolean DEBUG = false;
+
     private final String version;
     private final List<String> pluginNames;
     private final List<String> recipes;
@@ -94,6 +97,10 @@ public class Config {
 
     public boolean isDryRun() {
         return dryRun;
+    }
+
+    public boolean isDebug() {
+        return DEBUG;
     }
 
     public boolean isSkipPullRequest() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -210,6 +210,9 @@ public class MavenInvoker {
         InvocationRequest request = new DefaultInvocationRequest();
         request.setPomFile(plugin.getLocalRepository().resolve("pom.xml").toFile());
         request.addArgs(List.of(args));
+        if (config.isDebug()) {
+            request.addArg("-X");
+        }
         return request;
     }
 


### PR DESCRIPTION
Use `-X` flag when running in debug mode

### Testing done

Automated tests and checking logs to ensure maven ran in debug mode

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
