### PR TITLE
Remove pointless message for slf4j

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -27,6 +27,7 @@ import picocli.CommandLine.Option;
 public class Main implements Runnable {
 
     static {
+        System.setProperty("slf4j.internal.verbosity", "WARN");
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
     }


### PR DESCRIPTION
Seems recent upgrade of slf4j (Maybe https://github.com/jenkinsci/plugin-modernizer-tool/pull/164) started to print message when tool is starting

```
SLF4J(I): Connected with provider of type [ch.qos.logback.classic.spi.LogbackServiceProvider]
```

This is not useful at all, we know that we are using logback as logger implementation

Removing this message 

See https://stackoverflow.com/questions/78063648/how-to-stop-slf4j-printing-a-pointless-information-message-at-startup

### Testing done

Ensuring the message disapear when running the tool after setting the system property

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
