### PR TITLE
Remove java.version of unused properties

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -134,7 +134,7 @@ public class MavenInvoker {
             Path jdkPath = plugin.getJdkPath();
             if (jdkPath != null) {
                 request.setJavaHome(jdkPath.toFile());
-                LOG.info("JDK home: {}", jdkPath);
+                LOG.debug("JDK home: {}", jdkPath);
             }
             request.setBatchMode(true);
             request.setNoTransferProgress(false);

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -53,6 +53,8 @@ description: Remove extra maven properties from the pom
 recipeList:
   - org.openrewrite.maven.RemoveProperty:
       propertyName: configuration-as-code.version
+  - org.openrewrite.maven.RemoveProperty:
+      propertyName: java.version
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.ReplaceLibrariesWithApiPlugin
@@ -83,6 +85,7 @@ recipeList:
   - org.openrewrite.jenkins.UpgradeVersionProperty:
       key: jenkins.version
       minimumVersion: 2.440.3
+  - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
 ---


### PR DESCRIPTION
The java.version is deprecated and should be removed on recent pom

Also reduce some logs in debug

Also we must upgrade the parent when we upgrade to recommended core version

Not upgrading the parent bump but increasing the core version could cause issue like https://github.com/jenkinsci/plugin-pom/commit/8d4ac58c1f94dffae6140432d728c2e01daeab19 because missing ignore rules for upper bounds error

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
