### PR TITLE
Validate pom.xml existence

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -126,6 +126,7 @@ public class MavenInvoker {
      * @param goals The list of goals to run
      */
     private void invokeGoals(Plugin plugin, String... goals) {
+        validatePom(plugin);
         Invoker invoker = new DefaultInvoker();
         invoker.setMavenHome(config.getMavenHome().toFile());
         try {
@@ -150,6 +151,17 @@ public class MavenInvoker {
         } catch (MavenInvocationException e) {
             LOG.error(plugin.getMarker(), "Maven invocation failed: ", e);
             plugin.addError(e);
+        }
+    }
+
+    /**
+     * Validate a pom exist for the given plugin
+     * @param plugin The plugin to validate
+     */
+    private void validatePom(Plugin plugin) {
+        LOG.debug("Validating POM for plugin: {}", plugin);
+        if (!plugin.getLocalRepository().resolve("pom.xml").toFile().isFile()) {
+            throw new IllegalArgumentException("POM file not found for plugin: " + plugin.getName());
         }
     }
 


### PR DESCRIPTION
Instead of failing during maven invocation without much details, test pom.xml existence and return meaning full message

### Testing done

Tested with mesos plugin which is gradle based

![Screenshot from 2024-08-11 11-43-37](https://github.com/user-attachments/assets/1ce55b0b-543c-4ea7-9bff-4db548932ce6)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
