### PR TITLE
Print summary at end of process

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PomVersionProvider.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PomVersionProvider.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli;
 
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -16,14 +17,14 @@ public class PomVersionProvider implements CommandLine.IVersionProvider {
         Properties properties = new Properties();
         try (InputStream input = getClass().getClassLoader().getResourceAsStream("pom.properties")) {
             if (input == null) {
-                throw new IOException("Unable to find pom.properties");
+                throw new ModernizerException("Unable to find pom.properties");
             }
             properties.load(input);
         }
 
         String version = properties.getProperty("project.version");
         if (version == null || version.isEmpty()) {
-            throw new IOException("Version not found in pom.properties");
+            throw new ModernizerException("Version not found in pom.properties");
         }
 
         return version;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -2,6 +2,7 @@ package io.jenkins.tools.pluginmodernizer.core.config;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -78,7 +79,7 @@ public class Settings {
         try {
             DEFAULT_UPDATE_CENTER_URL = getUpdateCenterUrl();
         } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid URL format", e);
+            throw new ModernizerException("Invalid URL format", e);
         }
 
         // Get recipes module
@@ -88,7 +89,7 @@ public class Settings {
             AVAILABLE_RECIPES = yamlResourceLoader.listRecipes().stream().toList();
         } catch (IOException e) {
             LOG.error("Error reading recipes", e);
-            throw new IllegalArgumentException("Error reading recipes", e);
+            throw new ModernizerException("Error reading recipes", e);
         }
     }
 
@@ -173,7 +174,7 @@ public class Settings {
             properties.load(input);
         } catch (IOException e) {
             LOG.error("Error reading key {} from {}", key, resource, e);
-            throw new IllegalArgumentException("Error reading key " + key + " from " + resource, e);
+            throw new ModernizerException("Error reading key " + key + " from " + resource, e);
         }
 
         return properties.getProperty(key).trim();

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -1,8 +1,8 @@
 package io.jenkins.tools.pluginmodernizer.core.impl;
 
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.utils.JenkinsPluginInfo;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.slf4j.Logger;
@@ -24,9 +24,9 @@ public class CacheManager {
                     Files.createDirectory(parent);
                 }
                 Files.createDirectory(cache);
-                LOG.info("Creating cache at {}", cache);
+                LOG.debug("Creating cache at {}", cache);
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                throw new ModernizerException("Unable to create cache", e);
             }
         }
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -4,7 +4,9 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -21,7 +23,6 @@ import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.openrewrite.Recipe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MarkerFactory;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "false positive")
 public class MavenInvoker {
@@ -75,10 +76,9 @@ public class MavenInvoker {
      * @param goal The goal to run. For example, "clean"
      */
     public void invokeGoal(Plugin plugin, String goal) {
-        LOG.info(
-                "Invoking {} phase for plugin {} on directory {}",
-                goal,
-                plugin.getName(),
+        LOG.debug("Running {} phase for plugin {}", goal, plugin.getName());
+        LOG.debug(
+                "Running maven on directory {}",
                 plugin.getLocalRepository().toAbsolutePath().toFile());
         invokeGoals(plugin, goal);
     }
@@ -91,13 +91,15 @@ public class MavenInvoker {
         plugin.addTags(getActiveRecipes().stream()
                 .flatMap(recipe -> recipe.getTags().stream())
                 .collect(Collectors.toSet()));
-        LOG.info("Invoking rewrite plugin for plugin: {}", plugin);
+        LOG.info(
+                "Running recipes {} for plugin {}... Please be patient", String.join(",", config.getRecipes()), plugin);
         invokeGoals(plugin, getRewriteArgs());
+        LOG.info("Done");
     }
 
     /**
      * Get the rewrite arguments to be executed for each plugin
-     * @return The list of arguments to be passed to the rewrite plugin
+     * @return The list of arguments to be passed tomv the rewrite plugin
      */
     private String[] getRewriteArgs() {
         List<String> goals = new ArrayList<>();
@@ -143,18 +145,15 @@ public class MavenInvoker {
             request.setBatchMode(true);
             request.setNoTransferProgress(false);
             request.setErrorHandler((message) -> {
-                LOG.error(
-                        MarkerFactory.getMarker(plugin.getName()),
-                        String.format("Something went wrong when running maven: %s", message));
+                LOG.error(plugin.getMarker(), String.format("Something went wrong when running maven: %s", message));
             });
             request.setOutputHandler((message) -> {
-                LOG.info(MarkerFactory.getMarker(plugin.getName()), message);
+                LOG.info(plugin.getMarker(), message);
             });
             InvocationResult result = invoker.execute(request);
             handleInvocationResult(plugin, result);
         } catch (MavenInvocationException e) {
-            LOG.error(plugin.getMarker(), "Maven invocation failed: ", e);
-            plugin.addError(e);
+            plugin.addError("Maven invocation failed", e);
         }
     }
 
@@ -165,7 +164,8 @@ public class MavenInvoker {
     private void validatePom(Plugin plugin) {
         LOG.debug("Validating POM for plugin: {}", plugin);
         if (!plugin.getLocalRepository().resolve("pom.xml").toFile().isFile()) {
-            throw new IllegalArgumentException("POM file not found for plugin: " + plugin.getName());
+            plugin.addError("POM file not found");
+            throw new PluginProcessingException("POM file not found", plugin);
         }
     }
 
@@ -177,12 +177,12 @@ public class MavenInvoker {
         Path mavenHome = config.getMavenHome();
         if (mavenHome == null) {
             LOG.error("Neither MAVEN_HOME nor M2_HOME environment variables are set.");
-            throw new IllegalArgumentException("Maven home directory not set.");
+            throw new ModernizerException("Maven home directory not set.");
         }
 
         if (!Files.isDirectory(mavenHome) || !Files.isExecutable(mavenHome.resolve("bin/mvn"))) {
             LOG.error("Invalid Maven home directory. Aborting build.");
-            throw new IllegalArgumentException("Invalid Maven home directory.");
+            throw new ModernizerException("Invalid Maven home directory.");
         }
     }
 
@@ -195,14 +195,14 @@ public class MavenInvoker {
         LOG.debug("Maven version detected: {}", mavenVersion);
         if (mavenVersion == null) {
             LOG.error("Failed to check Maven version. Aborting build.");
-            throw new IllegalArgumentException("Failed to check Maven version.");
+            throw new ModernizerException("Failed to check Maven version.");
         }
         if (mavenVersion.compareTo(Settings.MAVEN_MINIMAL_VERSION) < 0) {
             LOG.error(
                     "Maven version detected {}, is too old. Please use at least version {}",
                     mavenVersion,
                     Settings.MAVEN_MINIMAL_VERSION);
-            throw new IllegalArgumentException("Maven version is too old.");
+            throw new ModernizerException("Maven version is too old.");
         }
     }
 
@@ -211,7 +211,7 @@ public class MavenInvoker {
      */
     private void validateSelectedRecipes() {
         if (getActiveRecipes().isEmpty()) {
-            throw new IllegalArgumentException("No valid recipes selected. Please select at least one recipe.");
+            throw new ModernizerException("No valid recipes selected. Please select at least one recipe.");
         }
     }
 
@@ -238,12 +238,12 @@ public class MavenInvoker {
      */
     private void handleInvocationResult(Plugin plugin, InvocationResult result) {
         if (result.getExitCode() != 0) {
-            LOG.error(MarkerFactory.getMarker(plugin.getName()), "Build fail with code: {}", result.getExitCode());
+            LOG.error(plugin.getMarker(), "Build fail with code: {}", result.getExitCode());
             if (result.getExecutionException() != null) {
-                LOG.error(plugin.getMarker(), "Execution exception occurred: ", result.getExecutionException());
-                plugin.addError(result.getExecutionException());
+                plugin.addError("Maven generic exception occurred", result.getExecutionException());
             } else {
-                plugin.addError(new MavenInvocationException("Build failed with code: " + result.getExitCode()));
+                String errorMessage = "Build failed with code: " + result.getExitCode();
+                plugin.addError(errorMessage, new MavenInvocationException(errorMessage));
             }
         }
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/ModernizerException.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/ModernizerException.java
@@ -1,0 +1,12 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+public class ModernizerException extends RuntimeException {
+
+    public ModernizerException(String message) {
+        super(message);
+    }
+
+    public ModernizerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.core.model;
 
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
@@ -13,6 +14,8 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.github.GHRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
@@ -20,6 +23,13 @@ import org.slf4j.MarkerFactory;
  * Mutable class representing a Jenkins plugin to modernize and refactor
  */
 public class Plugin {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Plugin.class);
+
+    /**
+     * The configuration to use
+     */
+    private Config config;
 
     /**
      * The plugin name
@@ -47,9 +57,14 @@ public class Plugin {
     private boolean hasChangesPushed;
 
     /**
+     * Flag to indicate if the plugin has any pull request open
+     */
+    private boolean hasPullRequest;
+
+    /**
      * Return if the plugin has any error
      */
-    private final List<Exception> errors = new LinkedList<>();
+    private final List<PluginProcessingException> errors = new LinkedList<>();
 
     /**
      * Tags to apply on pull request for the applied changes
@@ -65,6 +80,16 @@ public class Plugin {
      */
     public static Plugin build(String name) {
         return new Plugin().withName(name);
+    }
+
+    /**
+     * Set the config of the plugin
+     * @param config The config
+     * @return Plugin object
+     */
+    public Plugin withConfig(Config config) {
+        this.config = config;
+        return this;
     }
 
     /**
@@ -134,6 +159,24 @@ public class Plugin {
     }
 
     /**
+     * Indicate that the plugin has a pull request open
+     * @return Plugin object
+     */
+    public Plugin withPullRequest() {
+        this.hasPullRequest = true;
+        return this;
+    }
+
+    /**
+     * Indicate that the plugin has no pull request open
+     * @return Plugin object
+     */
+    public Plugin withoutPullRequest() {
+        this.hasPullRequest = false;
+        return this;
+    }
+
+    /**
      * Return if the plugin has any commits
      * @return True if the plugin has commits
      */
@@ -150,6 +193,14 @@ public class Plugin {
     }
 
     /**
+     * Return if the plugin has any changes pushed and ready to be merged
+     * @return True if the plugin has changes pushed
+     */
+    public boolean hasPullRequest() {
+        return hasPullRequest;
+    }
+
+    /**
      * Return if the plugin has any errors
      * @return True if the plugin has errors
      */
@@ -158,11 +209,46 @@ public class Plugin {
     }
 
     /**
+     * Get the errors of the plugin
+     * @return List of errors
+     */
+    public List<PluginProcessingException> getErrors() {
+        return errors;
+    }
+
+    /**
      * Add an error to the plugin
+     * @param message The message
      * @param e The exception
      */
-    public void addError(Exception e) {
-        errors.add(e);
+    public void addError(String message, Exception e) {
+        LOG.error(getMarker(), message, e);
+        if (config.isDebug()) {
+            LOG.error(message, e);
+        } else {
+            LOG.error(message);
+        }
+        errors.add(new PluginProcessingException(message, e, this));
+    }
+
+    /**
+     * Add an error to the plugin
+     * @param message The message
+     */
+    public void addError(String message) {
+        LOG.error(message);
+        errors.add(new PluginProcessingException(message, this));
+    }
+
+    /**
+     * Raise the last error as exception of the plugin
+     * Do nothing if no errors
+     */
+    public void raiseLastError() throws PluginProcessingException {
+        if (!hasErrors()) {
+            return;
+        }
+        throw errors.get(errors.size() - 1);
     }
 
     /**
@@ -236,6 +322,14 @@ public class Plugin {
     }
 
     /**
+     * Get the path of the log file for the plugin
+     * @return Path of the log file
+     */
+    public Path getLogFile() {
+        return Path.of("logs", getName() + ".log");
+    }
+
+    /**
      * Get the login marker for the plugin
      * @return Marker object
      */
@@ -264,7 +358,9 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void compile(MavenInvoker maven) {
+        LOG.info("Compiling plugin {}... Please be patient", name);
         maven.invokeGoal(this, "compile");
+        LOG.info("Done");
     }
 
     /**
@@ -272,7 +368,9 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void verify(MavenInvoker maven) {
+        LOG.info("Verifying plugin {}... Please be patient", name);
         maven.invokeGoal(this, "verify");
+        LOG.info("Done");
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginProcessingException.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginProcessingException.java
@@ -1,0 +1,38 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+/**
+ * A plugin processing exception
+ */
+public class PluginProcessingException extends ModernizerException {
+
+    /**
+     * The plugin that caused the exception
+     */
+    private final Plugin plugin;
+
+    /**
+     * Create a new PluginProcessingException
+     * @param message The message
+     */
+    public PluginProcessingException(String message, Plugin plugin) {
+        this(message, null, plugin);
+    }
+
+    /**
+     * Create a new PluginProcessingException
+     * @param message The message
+     * @param cause The cause
+     */
+    public PluginProcessingException(String message, Throwable cause, Plugin plugin) {
+        super(message, cause);
+        this.plugin = plugin;
+    }
+
+    /**
+     * Get the plugin that caused the exception
+     * @return The plugin
+     */
+    public Plugin getPlugin() {
+        return plugin;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -213,7 +214,7 @@ public class JdkFetcher {
         } else if (normalizedOS.contains("linux")) {
             return "linux";
         } else {
-            throw new IllegalArgumentException("Unsupported OS: " + os);
+            throw new ModernizerException("Unsupported OS: " + os);
         }
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfo.java
@@ -3,11 +3,12 @@ package io.jenkins.tools.pluginmodernizer.core.utils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.UpdateCenterData;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -19,21 +20,23 @@ public class JenkinsPluginInfo {
     private static final Logger LOG = LoggerFactory.getLogger(JenkinsPluginInfo.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static String extractRepoName(String pluginName, Path cacheDir, URL updateCenterUrl) {
+    public static String extractRepoName(Plugin plugin, Path cacheDir, URL updateCenterUrl) {
         try {
             UpdateCenterData updateCenterData = getCachedUpdateCenterData(cacheDir, updateCenterUrl);
-            String scmUrl = updateCenterData.getScmUrl(pluginName);
+            String scmUrl = updateCenterData.getScmUrl(plugin);
 
             int lastSlashIndex = scmUrl.lastIndexOf('/');
             if (lastSlashIndex != -1 && lastSlashIndex < scmUrl.length() - 1) {
                 return scmUrl.substring(lastSlashIndex + 1);
             } else {
-                throw new IllegalArgumentException("Invalid SCM URL format: " + scmUrl);
+                plugin.addError("Invalid SCM URL format");
+                plugin.raiseLastError();
             }
         } catch (IOException e) {
-            LOG.error("Error extracting repository name: ", e);
-            throw new UncheckedIOException(e);
+            plugin.addError("Error extracting repository name", e);
+            plugin.raiseLastError();
         }
+        return null;
     }
 
     private static UpdateCenterData getCachedUpdateCenterData(Path cacheDir, URL updateCenterUrl) throws IOException {
@@ -55,7 +58,7 @@ public class JenkinsPluginInfo {
     }
 
     @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "safe url")
-    private static String fetchUpdateCenterData(URL updateCenterUrl) throws IOException {
+    private static String fetchUpdateCenterData(URL updateCenterUrl) {
         StringBuilder response = new StringBuilder();
 
         try (BufferedReader in =
@@ -65,7 +68,7 @@ public class JenkinsPluginInfo {
                 response.append(inputLine);
             }
         } catch (IOException e) {
-            throw new IOException("Error fetching update center data", e);
+            throw new ModernizerException("Error fetching update center data", e);
         }
 
         return response.toString();

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -101,7 +102,7 @@ public class GHServiceTest {
         doThrow(new IOException()).when(github).getRepository(eq("jenkinsci/fake-repo"));
 
         // Test
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(PluginProcessingException.class, () -> {
             service.getRepository(plugin);
         });
     }
@@ -129,7 +130,7 @@ public class GHServiceTest {
         doThrow(new IOException()).when(github).getRepository(eq("fake-owner/fake-repo"));
 
         // Test
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(PluginProcessingException.class, () -> {
             service.getRepositoryFork(plugin);
         });
     }
@@ -156,7 +157,7 @@ public class GHServiceTest {
         doReturn(true).when(config).isDryRun();
 
         // Test
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(PluginProcessingException.class, () -> {
             service.getRepositoryFork(plugin);
         });
     }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
@@ -198,9 +200,9 @@ public class PluginTest {
 
     @Test
     public void testHasErrors() {
-        Plugin plugin = Plugin.build("example");
+        Plugin plugin = Plugin.build("example").withConfig(mock(Config.class));
         assertFalse(plugin.hasErrors());
-        plugin.addError(new Exception("error"));
+        plugin.addError("error", new Exception("error"));
         assertTrue(plugin.hasErrors());
     }
 

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JenkinsPluginInfoTest.java
@@ -3,6 +3,9 @@ package io.jenkins.tools.pluginmodernizer.core.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -12,6 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 class JenkinsPluginInfoTest {
 
@@ -39,27 +43,31 @@ class JenkinsPluginInfoTest {
 
     @Test
     public void testExtractRepoNamePluginPresentWithoutUrl() {
-        String result = JenkinsPluginInfo.extractRepoName("login-theme", tempDir, null);
+        String result = JenkinsPluginInfo.extractRepoName(
+                Plugin.build("login-theme").withConfig(Mockito.mock(Config.class)), tempDir, null);
         assertEquals("login-theme-plugin", result);
     }
 
     @Test
     public void testExtractRepoNamePluginAbsentWithoutUrl() {
         Exception exception = assertThrows(RuntimeException.class, () -> {
-            JenkinsPluginInfo.extractRepoName("not-present", tempDir, null);
+            JenkinsPluginInfo.extractRepoName(
+                    Plugin.build("not-present").withConfig(Mockito.mock(Config.class)), tempDir, null);
         });
 
-        assertEquals("Plugin not found in update center: not-present", exception.getMessage());
+        assertEquals("Plugin not found in update center", exception.getMessage());
     }
 
     @Test
     public void testExtractRepoNamePluginPresentWithUrl() throws MalformedURLException {
         URL updateCenterUrl = new URL("https://updates.jenkins.io/current/update-center.actual.json");
 
-        String resultLoginTheme = JenkinsPluginInfo.extractRepoName("login-theme", tempDir2, updateCenterUrl);
+        String resultLoginTheme = JenkinsPluginInfo.extractRepoName(
+                Plugin.build("login-theme").withConfig(Mockito.mock(Config.class)), tempDir2, updateCenterUrl);
         assertEquals("login-theme-plugin", resultLoginTheme);
 
-        String resultJobCacher = JenkinsPluginInfo.extractRepoName("jobcacher", tempDir2, updateCenterUrl);
+        String resultJobCacher = JenkinsPluginInfo.extractRepoName(
+                Plugin.build("jobcacher").withConfig(Mockito.mock(Config.class)), tempDir2, updateCenterUrl);
         assertEquals("jobcacher-plugin", resultJobCacher);
     }
 
@@ -68,25 +76,28 @@ class JenkinsPluginInfoTest {
         URL updateCenterUrl = new URL("https://updates.jenkins.io/current/update-center.actual.json");
 
         Exception exception = assertThrows(RuntimeException.class, () -> {
-            JenkinsPluginInfo.extractRepoName("not-present", tempDir2, updateCenterUrl);
+            JenkinsPluginInfo.extractRepoName(
+                    Plugin.build("not-present").withConfig(Mockito.mock(Config.class)), tempDir2, updateCenterUrl);
         });
 
-        assertEquals("Plugin not found in update center: not-present", exception.getMessage());
+        assertEquals("Plugin not found in update center", exception.getMessage());
     }
 
     @Test
     public void testExtractRepoNameInvalidScmUrlFormat() {
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            JenkinsPluginInfo.extractRepoName("invalid-plugin", tempDir, null);
+        Exception exception = assertThrows(ModernizerException.class, () -> {
+            JenkinsPluginInfo.extractRepoName(
+                    Plugin.build("invalid-plugin").withConfig(Mockito.mock(Config.class)), tempDir, null);
         });
-        assertEquals("Invalid SCM URL format: invalid-scm-url", exception.getMessage());
+        assertEquals("Invalid SCM URL format", exception.getMessage());
     }
 
     @Test
     public void testExtractRepoNameInvalidScmUrlFormat2() {
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            JenkinsPluginInfo.extractRepoName("invalid-plugin-2", tempDir, null);
+        Exception exception = assertThrows(ModernizerException.class, () -> {
+            JenkinsPluginInfo.extractRepoName(
+                    Plugin.build("invalid-plugin-2").withConfig(Mockito.mock(Config.class)), tempDir, null);
         });
-        assertEquals("Invalid SCM URL format: /", exception.getMessage());
+        assertEquals("Invalid SCM URL format", exception.getMessage());
     }
 }


### PR DESCRIPTION
Print summary at the end of process.

Closes https://github.com/jenkinsci/plugin-modernizer-tool/issues/88
Partially closes https://github.com/jenkinsci/plugin-modernizer-tool/issues/143

Can be improved also in the future if some information is missing

Basically

- Add 2 new exception (one general and one for plugin processing)
- Cleanup a bit some logs levels
- Print summary at the end

Example is

![summary](https://github.com/user-attachments/assets/0ee5cef0-32c7-41f0-b07c-af3842741fe2)


### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
