### PR TITLE
Fix isForked() to check only the current github owner

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -109,8 +109,11 @@ public class GHService {
      */
     public boolean isForked(Plugin plugin) {
         try {
-            return isRepositoryForked(plugin.getRepositoryName())
-                    || isRepositoryForked(getOrganization(), plugin.getRepositoryName());
+            GHOrganization organization = getOrganization();
+            if (organization != null) {
+                return isRepositoryForked(organization, plugin.getRepositoryName());
+            }
+            return isRepositoryForked(plugin.getRepositoryName());
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to check if repository is forked", e);
         }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
@@ -195,12 +195,9 @@ public class GHServiceTest {
 
         // Mock
         GHRepository fork = Mockito.mock(GHRepository.class);
-        GHMyself myself = Mockito.mock(GHMyself.class);
         GHOrganization org = Mockito.mock(GHOrganization.class);
 
         doReturn("fake-repo").when(plugin).getRepositoryName();
-        doReturn(myself).when(github).getMyself();
-        doReturn(null).when(myself).getRepository(eq("fake-repo"));
         doReturn(org).when(github).getOrganization(eq("fake-owner"));
         doReturn(fork).when(org).getRepository(eq("fake-repo"));
 


### PR DESCRIPTION
The implementation was too permission to do an ||

It can cause issue if the repo is already forked on personal account but non on your organisation.

The isForked() could return true which cause issue later when getting the repo from organisation.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
