### PR TITLE
Use github primary email for committer that match GH_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ This tool requires forking repositories from GitHub, so you need to set the GitH
 Use either `GH_TOKEN` or `GITHUB_TOKEN` for the GitHub token, and either `GH_OWNER` or `GITHUB_OWNER` for the GitHub owner.
 Alternatively, you can pass the GitHub owner through the CLI option `-g` or `--github-owner`.
 
+Your classic token should have the following scopes
+
+- `repo` (Full control of private repositories)
+- `user:email` (Read-only access to email addresses)
+- `delete_repo` (Delete repositories) (Only if using the `--clean-forks` option)
+
 > [!Note]
 > The GitHub owner can be either a personal account or an organization.
 >


### PR DESCRIPTION
If not jgit will fallback to .gitconfig which might not exist on some system (specially when distributing the jar directly)

### Testing done

Run 

```
java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --skip-push --source-java-major-version 11 --target-java-major-version 17  --plugins login-theme --github-owner jonesbusy-automation --recipes UpgradeToRecommendCoreVersion,UpgradeBomVersion
```

And check the commit match my primary email

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
