### PR TITLE
Add JDK model and attempt of JDK compilation until it works

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -2,6 +2,7 @@ package io.jenkins.tools.pluginmodernizer.core.config;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.jenkins.tools.pluginmodernizer.core.model.JDK;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,14 +51,9 @@ public class Settings {
 
     public static final List<Recipe> AVAILABLE_RECIPES;
 
-    // Default JDK home from sdk man
-    public static final int SOURCE_JAVA_MAJOR_VERSION = 8;
-    public static final int TARGET_JAVA_MAJOR_VERSION = 17;
-
-    public static final Path DEFAULT_JAVA_8_HOME = getDefaultSdkManJava("JAVA_8_HOME");
-    public static final Path DEFAULT_JAVA_11_HOME = getDefaultSdkManJava("JAVA_11_HOME");
-    public static final Path DEFAULT_JAVA_17_HOME = getDefaultSdkManJava("JAVA_17_HOME");
-    public static final Path DEFAULT_JAVA_21_HOME = getDefaultSdkManJava("JAVA_21_HOME");
+    // Default JDK to use when compiling plugin
+    public static final int SOURCE_JAVA_MAJOR_VERSION = JDK.getDefaultSource().getMajor();
+    public static final int TARGET_JAVA_MAJOR_VERSION = JDK.getDefaultTarget().getMajor();
 
     private Settings() {}
 
@@ -92,26 +88,6 @@ public class Settings {
         } catch (IOException e) {
             LOG.error("Error reading recipes", e);
             throw new ModernizerException("Error reading recipes", e);
-        }
-    }
-
-    /**
-     * Get the path to the Java version to use
-     * @param majorVersion The major version of Java to get
-     * @return The path to the Java version
-     */
-    public static Path getJavaVersionPath(int majorVersion) {
-        switch (majorVersion) {
-            case 8:
-                return DEFAULT_JAVA_8_HOME;
-            case 11:
-                return DEFAULT_JAVA_11_HOME;
-            case 17:
-                return DEFAULT_JAVA_17_HOME;
-            case 21:
-                return DEFAULT_JAVA_21_HOME;
-            default:
-                return DEFAULT_JAVA_8_HOME;
         }
     }
 
@@ -154,7 +130,7 @@ public class Settings {
         return username;
     }
 
-    private static Path getDefaultSdkManJava(final String key) {
+    public static Path getDefaultSdkManJava(final String key) {
         String homeDir = System.getProperty("user.home") != null ? System.getProperty("user.home") : "";
         String propertyValue = readProperty(key, "sdkman.properties").replace("$HOME", homeDir);
         return Path.of(propertyValue);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -1,0 +1,149 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import io.jenkins.tools.pluginmodernizer.core.utils.JdkFetcher;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * JDK enum to compile and build a Jenkins plugin
+ * Most of the time only LTS are available, but adding new version would
+ * be useful to test compilation for new major LTS version and be ready every
+ * 2 years when a new LTS is released.
+ * See <a href="https://www.jenkins.io/blog/2023/11/06/introducing-2-2-2-java-support-plan/">2+2+2 Jenkins Java support plan</a> for details
+ */
+public enum JDK {
+
+    /**
+     * Available JDKs
+     */
+    JAVA_8(8, true),
+    JAVA_11(11, true),
+    JAVA_17(17, true),
+    JAVA_21(21, true);
+
+    /**
+     * The major version
+     */
+    private final int major;
+
+    /**
+     * If the major
+     */
+    private final boolean lts;
+
+    /**
+     * Constructor
+     * @param major The major version
+     */
+    JDK(int major, boolean lts) {
+        this.major = major;
+        this.lts = lts;
+    }
+
+    /**
+     * Get the major version
+     * @return The major version
+     */
+    public int getMajor() {
+        return major;
+    }
+
+    /**
+     * Check if the JDK is LTS
+     * @return True if LTS
+     */
+    public boolean isLts() {
+        return lts;
+    }
+
+    /**
+     * Get the JDK home for this enum
+     * @param jdkFetcher The JDK fetcher use to download the JDK
+     * @return The JDK home
+     * @throws IOException If an error occurs
+     * @throws InterruptedException If an error occurs
+     */
+    public Path getHome(JdkFetcher jdkFetcher) throws IOException, InterruptedException {
+        return Files.isDirectory(getDefaultSdkMan()) ? getDefaultSdkMan() : jdkFetcher.getJdkPath(major);
+    }
+
+    /**
+     * Return the next JDK available
+     * @return The next JDK
+     */
+    public JDK next() {
+        int major = getMajor();
+        return Arrays.stream(JDK.values())
+                .sorted(Comparator.comparingInt(JDK::getMajor))
+                .filter(jdk -> jdk.getMajor() > major)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Has next predicate
+     * @param jdk The JDK
+     * @return True if there is a next JDK
+     */
+    public static boolean hasNext(JDK jdk) {
+        return jdk.next() != null;
+    }
+
+    public final int compareMajor(JDK jdk) {
+        return Integer.compare(this.getMajor(), jdk.getMajor());
+    }
+
+    /**
+     * Get the JDK home for SDK man
+     * @return The JDK home
+     */
+    private Path getDefaultSdkMan() {
+        return Settings.getDefaultSdkManJava(this.name() + "_HOME");
+    }
+
+    /**
+     * Get the JDK for a major version
+     * @param major The major version
+     * @return The JDK or null if not found
+     */
+    public static JDK get(int major) {
+        return Arrays.stream(JDK.values())
+                .filter(j -> j.getMajor() == major)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Get the latest JDK available
+     * @return The latest JDK
+     */
+    public static JDK max() {
+        JDK jdk = null;
+        for (JDK j : JDK.values()) {
+            if (jdk == null || j.getMajor() > jdk.getMajor()) {
+                jdk = j;
+            }
+        }
+        return jdk;
+    }
+
+    /**
+     * Get the default source JDK to compile before modernization
+     * @return The default source JDK
+     */
+    public static JDK getDefaultSource() {
+        return JDK.JAVA_8;
+    }
+
+    /**
+     * Get the default target JDK to compile after modernization
+     * @return The default target JDK
+     */
+    public static JDK getDefaultTarget() {
+        return JDK.JAVA_17;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -42,9 +42,9 @@ public class Plugin {
     private String repositoryName;
 
     /**
-     * The path to the JDK directory
+     * The JDK to use
      */
-    private Path jdkPath;
+    private JDK jdk;
 
     /**
      * Flag to indicate if the plugin has any commits to be pushed
@@ -113,12 +113,12 @@ public class Plugin {
     }
 
     /***
-     * Set the path of the JDK directory
-     * @param jdkPath Path of the JDK directory
+     * Set the current JDK
+     * @param jdk The JDK
      * @return Plugin object
      */
-    public Plugin withJdkPath(Path jdkPath) {
-        this.jdkPath = jdkPath;
+    public Plugin withJDK(JDK jdk) {
+        this.jdk = jdk;
         return this;
     }
 
@@ -281,6 +281,15 @@ public class Plugin {
     }
 
     /**
+     * Remove errors from the plugin
+     * @return Plugin object
+     */
+    public Plugin withoutErrors() {
+        errors.clear();
+        return this;
+    }
+
+    /**
      * Get the name of the plugin
      * @return Name of the plugin
      */
@@ -317,8 +326,8 @@ public class Plugin {
      * Get the path of the JDK directory
      * @return Path of the JDK directory
      */
-    public Path getJdkPath() {
-        return jdkPath;
+    public JDK getJDK() {
+        return jdk;
     }
 
     /**
@@ -358,9 +367,14 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void compile(MavenInvoker maven) {
-        LOG.info("Compiling plugin {}... Please be patient", name);
+        LOG.info(
+                "Compiling plugin {} with JDK {} ... Please be patient",
+                name,
+                this.getJDK().getMajor());
         maven.invokeGoal(this, "compile");
-        LOG.info("Done");
+        if (!hasErrors()) {
+            LOG.info("Done");
+        }
     }
 
     /**
@@ -368,7 +382,10 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void verify(MavenInvoker maven) {
-        LOG.info("Verifying plugin {}... Please be patient", name);
+        LOG.info(
+                "Verifying plugin {} with JDK {}... Please be patient",
+                name,
+                this.getJDK().getMajor());
         maven.invokeGoal(this, "verify");
         LOG.info("Done");
     }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -1,0 +1,30 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class JDKTest {
+
+    // Write tests for JDK enum here
+    @Test
+    public void shouldNext() {
+        assertEquals(JDK.JAVA_11, JDK.JAVA_8.next());
+        assertEquals(JDK.JAVA_17, JDK.JAVA_11.next());
+        assertEquals(JDK.JAVA_21, JDK.JAVA_17.next());
+        assertEquals(null, JDK.JAVA_21.next());
+    }
+
+    public void shouldGet() {
+        assertEquals(JDK.JAVA_8, JDK.get(8));
+        assertEquals(JDK.JAVA_11, JDK.get(11));
+        assertEquals(JDK.JAVA_17, JDK.get(17));
+        assertEquals(JDK.JAVA_21, JDK.get(21));
+    }
+
+    @Test
+    public void currentMax() {
+        // Adapt when new JDK are added
+        assertEquals(JDK.JAVA_21, JDK.max());
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
@@ -89,6 +89,7 @@ public class PluginTest {
     @Test
     public void testCompile() {
         Plugin plugin = Plugin.build("example");
+        plugin.withJDK(JDK.JAVA_21);
         plugin.compile(mavenInvoker);
         verify(mavenInvoker).invokeGoal(plugin, "compile");
         verifyNoMoreInteractions(mavenInvoker);
@@ -97,6 +98,7 @@ public class PluginTest {
     @Test
     public void testVerify() {
         Plugin plugin = Plugin.build("example");
+        plugin.withJDK(JDK.JAVA_21);
         plugin.verify(mavenInvoker);
         verify(mavenInvoker).invokeGoal(plugin, "verify");
         verifyNoMoreInteractions(mavenInvoker);


### PR DESCRIPTION
Add JDK module

`--source-java-major-version`and `--target-java-major-version` are now less necessary unless you know in advance the plugin you want to modernize are working on a specific JDK version

Unless I miss something this should close #120

The minimum JDK version can now be determined before applying the recipes

### Testing done

Some automated for the model or interactive tests

![Screenshot from 2024-08-17 19-28-42](https://github.com/user-attachments/assets/709a24b6-b5ee-4ca5-ab99-6806ac849d37)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
