### PR TITLE
Fetch metadata at each invocation and link it to plugin

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -51,6 +51,8 @@ public class Settings {
 
     public static final List<Recipe> AVAILABLE_RECIPES;
 
+    public static final Recipe FETCH_METADATA_RECIPE;
+
     // Default JDK to use when compiling plugin
     public static final int SOURCE_JAVA_MAJOR_VERSION = JDK.getDefaultSource().getMajor();
     public static final int TARGET_JAVA_MAJOR_VERSION = JDK.getDefaultTarget().getMajor();
@@ -89,6 +91,12 @@ public class Settings {
             LOG.error("Error reading recipes", e);
             throw new ModernizerException("Error reading recipes", e);
         }
+
+        FETCH_METADATA_RECIPE = AVAILABLE_RECIPES.stream()
+                .filter(recipe -> recipe.getName().equals("io.jenkins.tools.pluginmodernizer.FetchMetadata"))
+                .findFirst()
+                .orElseThrow(() ->
+                        new ModernizerException("io.jenkins.tools.pluginmodernizer.FetchMetadata recipe not found"));
     }
 
     private static Path getDefaultMavenHome() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -97,6 +97,16 @@ public class MavenInvoker {
      * Invoke the rewrite modernization for a given plugin
      * @param plugin The plugin to run the rewrite on
      */
+    public void collectMetadata(Plugin plugin) {
+        LOG.info("Collecting metadata for plugin {}... Please be patient", plugin);
+        invokeGoals(plugin, getSingleRecipeArgs(Settings.FETCH_METADATA_RECIPE));
+        LOG.info("Done");
+    }
+
+    /**
+     * Invoke the rewrite modernization for a given plugin
+     * @param plugin The plugin to run the rewrite on
+     */
     public void invokeRewrite(Plugin plugin) {
         plugin.addTags(getActiveRecipes().stream()
                 .flatMap(recipe -> recipe.getTags().stream())
@@ -108,8 +118,22 @@ public class MavenInvoker {
     }
 
     /**
+     * Get the rewrite arguments to be executed for metadata collection
+     * @return The list of arguments to be passed to the rewrite plugin
+     */
+    private String[] getSingleRecipeArgs(Recipe recipe) {
+        List<String> goals = new ArrayList<>();
+        goals.add("org.openrewrite.maven:rewrite-maven-plugin:" + Settings.MAVEN_REWRITE_PLUGIN_VERSION + ":run");
+        goals.add("-Drewrite.exportDatatables=" + config.isExportDatatables());
+        goals.add("-Drewrite.activeRecipes=" + recipe.getName());
+        goals.add("-Drewrite.recipeArtifactCoordinates=io.jenkins.plugin-modernizer:plugin-modernizer-core:"
+                + config.getVersion());
+        return goals.toArray(String[]::new);
+    }
+
+    /**
      * Get the rewrite arguments to be executed for each plugin
-     * @return The list of arguments to be passed tomv the rewrite plugin
+     * @return The list of arguments to be passed to the rewrite plugin
      */
     private String[] getRewriteArgs() {
         List<String> goals = new ArrayList<>();

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.core.impl;
 
+import com.google.gson.Gson;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
@@ -122,6 +123,14 @@ public class PluginModernizer {
 
             // Switch to the target JDK path
             plugin.withJDK(jdkTarget);
+
+            // Collect metadata
+            plugin.collectMetadata(mavenInvoker);
+            plugin.readMetadata();
+
+            // TODO: Just a test, we need a better CacheManager that manage CacheEntry rather than String that require
+            // serialization from caller. Probably also some GSON serialization are missing
+            cacheManager.addToCache(plugin.getName() + "-metadata", new Gson().toJson(plugin.getMetadata()));
 
             // Run OpenRewrite
             plugin.runOpenRewrite(mavenInvoker);


### PR DESCRIPTION
Fetch metadata at each invocation and link it to plugin

### Testing done

Automated tests and checking the cache content

For the moment there is just a TODO in order to save this content on the cache. This need to be improved when we actually use this metadata

![Screenshot from 2024-08-17 21-37-43](https://github.com/user-attachments/assets/7bb88391-73c8-4fc7-9d00-cb03a583a384)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
