### PR TITLE
Add JSON Utils and CacheEntry

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -44,8 +44,6 @@ public class Settings {
 
     public static final String ADOPTIUM_GITHUB_API_URL = "https://api.github.com/repos/adoptium";
 
-    public static final String UPDATE_CENTER_CACHE_KEY = "update-center";
-
     public static final ComparableVersion MAVEN_MINIMAL_VERSION = new ComparableVersion("3.9.7");
 
     public static final List<Recipe> AVAILABLE_RECIPES;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollector.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollector.java
@@ -1,12 +1,5 @@
 package io.jenkins.tools.pluginmodernizer.core.extractor;
 
-import com.google.gson.Gson;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
@@ -111,15 +104,8 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
                 pluginMetadata.setHasJenkinsfile(acc.hasJenkinsfile);
 
                 // Write the metadata to a file for later use by the plugin modernizer.
-                Path path = Paths.get("target/pluginMetadata.json");
-                try (OutputStreamWriter writer =
-                        new OutputStreamWriter(new FileOutputStream(path.toFile()), StandardCharsets.UTF_8)) {
-                    Gson gson = new Gson();
-                    gson.toJson(pluginMetadata, writer);
-                    LOG.debug("Plugin metadata written to {}", path);
-                } catch (IOException e) {
-                    LOG.error(e.getMessage(), e);
-                }
+                pluginMetadata.save();
+                LOG.debug("Plugin metadata written to {}", pluginMetadata.getRelativePath());
 
                 return document;
             }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -1,12 +1,16 @@
 package io.jenkins.tools.pluginmodernizer.core.extractor;
 
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import io.jenkins.tools.pluginmodernizer.core.model.CacheEntry;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
  * Metadata of a plugin extracted from its POM file or code
  */
-public class PluginMetadata implements Serializable {
+public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serializable {
 
     /**
      * Name of the plugin
@@ -48,7 +52,26 @@ public class PluginMetadata implements Serializable {
      */
     private Map<String, String> properties;
 
-    public PluginMetadata() {}
+    /**
+     * Create a new plugin metadata
+     * Store the metadata in in the relative target directory of current folder
+     */
+    public PluginMetadata() {
+        super(
+                new CacheManager(Path.of("target")),
+                PluginMetadata.class,
+                CacheManager.PLUGIN_METADATA_CACHE_KEY,
+                Path.of("."));
+    }
+
+    /**
+     * Create a new plugin metadata. Store the metadata to the plugin subdirectory of the given cache manager
+     * @param cacheManager The cache manager
+     * @param plugin The plugin
+     */
+    public PluginMetadata(CacheManager cacheManager, Plugin plugin) {
+        super(cacheManager, PluginMetadata.class, CacheManager.PLUGIN_METADATA_CACHE_KEY, Path.of(plugin.getName()));
+    }
 
     public String getPluginName() {
         return pluginName;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
@@ -1,0 +1,108 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils;
+import java.io.Serializable;
+import java.nio.file.Path;
+
+public abstract class CacheEntry<T extends CacheEntry<T>> implements Serializable {
+
+    /**
+     * Key of the cache
+     */
+    public final String key;
+
+    /**
+     * Relative path of the object
+     */
+    public final transient Path path;
+
+    /**
+     * Cache manager
+     */
+    private final transient CacheManager cacheManager;
+
+    /**
+     * Concrete class of the object
+     */
+    private final transient Class<T> clazz;
+
+    /**
+     * Create a new cache entry
+     * @param cacheManager The cache manager
+     * @param key The key of the cache
+     * @param path Relative path of the object
+     */
+    public CacheEntry(CacheManager cacheManager, Class<T> clazz, String key, Path path) {
+        this.key = key;
+        this.path = path;
+        this.cacheManager = cacheManager;
+        this.clazz = clazz;
+    }
+
+    /**
+     * Delete the object from cache
+     */
+    public final void delete() {
+        cacheManager.remove(path, key);
+    }
+
+    /**
+     * Return the key of the cache
+     * @return The key
+     */
+    public final String getKey() {
+        return key;
+    }
+
+    /**
+     * Return a copy of this object refreshed from the cache
+     * @return The refreshed object
+     */
+    public final T refresh() {
+        return JsonUtils.fromJson(cacheManager.get(path, key), clazz);
+    }
+
+    /**
+     * Return a copy of this object moved to another cache manager
+     * @param newCacheManager The new cache manager
+     * @return The refreshed object copied
+     */
+    public final T move(CacheManager newCacheManager) {
+        T refreshed = refresh();
+        newCacheManager.put(path, key, refresh().toJson());
+        this.delete();
+        return refreshed;
+    }
+
+    /**
+     * Save this object to the cache
+     */
+    public final void save() {
+        cacheManager.put(path, key, toJson());
+    }
+
+    /**
+     * Return the relative path of the object
+     * @return The relative path
+     */
+    public final Path getRelativePath() {
+        return path;
+    }
+
+    /**
+     * Return the absolute path of the object
+     * @return The absolute path
+     */
+    public final Path getAbsolutePath() {
+        return cacheManager.getLocation().resolve(path);
+    }
+
+    /**
+     * Return this object to JSON
+     * @return The JSON string
+     */
+    public final String toJson() {
+        return JsonUtils.toJson(this);
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -1,16 +1,13 @@
 package io.jenkins.tools.pluginmodernizer.core.model;
 
-import com.google.gson.Gson;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -534,29 +531,19 @@ public class Plugin {
     }
 
     /**
-     * Read plugin metadata and save in memory
-     */
-    public void readMetadata() {
-        Gson gson = new Gson();
-        try (FileReader reader = new FileReader(
-                getLocalRepository()
-                        .resolve("target")
-                        .resolve("pluginMetadata.json")
-                        .toFile(),
-                StandardCharsets.UTF_8)) {
-            metadata = gson.fromJson(reader, PluginMetadata.class);
-        } catch (IOException e) {
-            addError("Failed to read plugin metadata", e);
-            raiseLastError();
-        }
-    }
-
-    /**
      * Get the metadata of the plugin
      * @return Plugin metadata
      */
     public PluginMetadata getMetadata() {
         return metadata;
+    }
+
+    /**
+     * Set the metadata of the plugin
+     * @param metadata Plugin metadata
+     */
+    public void setMetadata(PluginMetadata metadata) {
+        this.metadata = metadata;
     }
 
     @Override

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/UpdateCenterData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/UpdateCenterData.java
@@ -1,13 +1,18 @@
 package io.jenkins.tools.pluginmodernizer.core.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
 
-public class UpdateCenterData {
+public class UpdateCenterData extends CacheEntry<UpdateCenterData> implements Serializable {
+
     private final JsonNode jsonNode;
 
-    public UpdateCenterData(JsonNode jsonNode) {
+    public UpdateCenterData(CacheManager cacheManager, JsonNode jsonNode) {
+        super(cacheManager, UpdateCenterData.class, CacheManager.UPDATE_CENTER_CACHE_KEY, Path.of("."));
         this.jsonNode = Objects.requireNonNull(jsonNode, "jsonNode must not be null");
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
@@ -1,0 +1,69 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import com.google.gson.Gson;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+
+public class JsonUtils {
+
+    private static final Gson gson;
+
+    private JsonUtils() {
+        // Hide constructor
+    }
+
+    static {
+        gson = new Gson();
+    }
+
+    /**
+     * Convert an object to a JSON string
+     * @param object The object to convert
+     * @return The JSON string
+     */
+    public static String toJson(Object object) {
+        return gson.toJson(object);
+    }
+
+    /**
+     * Convert an object to a JSON file
+     * @param object The object to convert
+     * @param path The path to the JSON file
+     */
+    public static void toJsonFile(Object object, Path path) {
+        try {
+            FileUtils.writeStringToFile(path.toFile(), gson.toJson(object), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new ModernizerException("Unable to write JSON file due to IO error", e);
+        }
+    }
+
+    /**
+     * Convert a JSON string to an object
+     * @param json The JSON string
+     * @param clazz The class of the object
+     * @param <T> The type of the object
+     * @return The object
+     */
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        return gson.fromJson(json, clazz);
+    }
+
+    /**
+     * Convert a JSON string to an object
+     * @param path The path to the JSON file
+     * @param clazz The class of the object
+     * @param <T> The type of the object
+     * @return The object
+     */
+    public static <T> T fromJson(Path path, Class<T> clazz) {
+        try {
+            return gson.fromJson(FileUtils.readFileToString(path.toFile(), StandardCharsets.UTF_8), clazz);
+        } catch (IOException e) {
+            throw new ModernizerException("Unable to read JSON file due to IO error", e);
+        }
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
@@ -6,11 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-import com.google.gson.Gson;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -132,10 +128,7 @@ public class MetadataCollectorTest implements RewriteTest {
                           </pluginRepositories>
                         </project>
                         """));
-        PluginMetadata pluginMetadata = new Gson()
-                .fromJson(
-                        FileUtils.readFileToString(new File("target/pluginMetadata.json"), StandardCharsets.UTF_8),
-                        PluginMetadata.class);
+        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         String pluginName = pluginMetadata.getPluginName();
         assertEquals("GitLab Plugin", pluginName);
         assertEquals("4.80", pluginMetadata.getParentVersion());


### PR DESCRIPTION
Add some JSON utility using GSON implementation and `CacheEntry` abstract class

There are some other place we need to uniformize the serializaton that still using Jackson and not this class

Also the `UpdateCenterData` need to contains field  we need instead of storing a reference on `JsonNode`. Need to be done in an other PR to manage our cached entities the same way (maybe using `@Expose`)

### Testing done


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
