### PR TITLE
Restore license ans developer tags

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFlag.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFlag.java
@@ -32,13 +32,47 @@ public enum MetadataFlag {
                     .allMatch(url -> url.startsWith("https"));
         }
         return false;
+    }),
+
+    /**
+     * If the license block is set
+     */
+    LICENSE_SET(tag -> {
+        if ("licenses".equals(tag.getName())) {
+            return tag.getChildren().stream()
+                    .filter(c -> "license".equals(c.getName()))
+                    .map(Xml.Tag.class::cast)
+                    .map(r -> r.getChildValue("name").orElseThrow())
+                    .findAny()
+                    .isPresent();
+        }
+        return false;
+    }),
+
+    /**
+     * If the develop block is set
+     */
+    DEVELOPER_SET(tag -> {
+        if ("developers".equals(tag.getName())) {
+            return tag.getChildren().stream()
+                    .filter(c -> "developer".equals(c.getName()))
+                    .map(Xml.Tag.class::cast)
+                    .map(r -> r.getChildValue("id").orElseThrow())
+                    .findAny()
+                    .isPresent();
+        }
+        return false;
     });
 
     /**
      * Function to check if the flag is applicable for the given XML tag
      */
-    private Predicate<Xml.Tag> isApplicable;
+    private final Predicate<Xml.Tag> isApplicable;
 
+    /**
+     * Constructor
+     * @param isApplicable Predicate to check if the flag is applicable for the given XML tag
+     */
     MetadataFlag(Predicate<Xml.Tag> isApplicable) {
         this.isApplicable = isApplicable;
     }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
@@ -46,7 +46,13 @@ public class MetadataCollectorTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>GitLab Plugin</name>
                           <url>https://github.com/jenkinsci/${project.artifactId}</url>
-
+                          <developers>
+                            <developer>
+                              <id>john.doe</id>
+                              <name>John Doe</name>
+                              <email>john.doe@example.com</email>
+                            </developer>
+                          </developers>
                           <licenses>
                             <license>
                               <name>GPL v2.0 License</name>
@@ -145,6 +151,8 @@ public class MetadataCollectorTest implements RewriteTest {
         assertNotNull(pluginMetadata.getProperties().get("java.level"));
         assertTrue(pluginMetadata.hasFlag(MetadataFlag.SCM_HTTPS));
         assertTrue(pluginMetadata.hasFlag(MetadataFlag.MAVEN_REPOSITORIES_HTTPS));
+        assertTrue(pluginMetadata.hasFlag(MetadataFlag.LICENSE_SET));
+        assertTrue(pluginMetadata.hasFlag(MetadataFlag.DEVELOPER_SET));
         Map<String, String> properties = pluginMetadata.getProperties();
         assertNotNull(properties);
         assertEquals(10, properties.size());


### PR DESCRIPTION
Restoring such metadata deleted on previous PR

- License block is present on archetype and can be useful to add if not present
- Developer block is not present anymore on archetype and was used long time ago for maintainainer list. This is now replaced by the RPU. I saw many plugin with deprecated list and should bean cleaned on my opinion

### Testing done

Automated tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
