### PR TITLE
Fix #206 possible nullpointer when verifying plugin

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -226,7 +226,7 @@ public class PluginModernizer {
             return null;
         }
         String coreVersion = metadata.getJenkinsVersion();
-        return Stream.iterate(JDK.max(), JDK::previous)
+        return Stream.iterate(JDK.max(), JDK::hasPrevious, JDK::previous)
                 .filter(j -> j.supported(coreVersion))
                 .filter(j -> {
                     plugin.withJDK(j);


### PR DESCRIPTION
Missing predicate on stream iteration to avoid null values

Fix #206

### Testing done

```
java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --debug --dry-run --plugins alauda-kubernetes-support --github-owner jonesbusy-automation --recipes UpgradeBomVersion
```

```
Plugin alauda-kubernetes-support failed to verify with all JDKs. Aborting this plugin.
*************
Plugin: alauda-kubernetes-support
Error: Plugin failed to verify with all JDKs.
```

But the plugin fail it's tests, I don't see result on ci.jenkins.io. Probably broken. But this is an other story



### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
