### PR TITLE
Optimize Metadata fetch 

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -69,6 +69,14 @@ public class Config {
         return recipes;
     }
 
+    /**
+     * Return if the current configuration is only fetching metadata which will skip compile and verify steps
+     * @return True if only fetching metadata
+     */
+    public boolean isFetchMetadataOnly() {
+        return recipes.size() == 1 && recipes.get(0).equals(Settings.FETCH_METADATA_RECIPE.getName());
+    }
+
     public URL getJenkinsUpdateCenter() {
         return jenkinsUpdateCenter;
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -141,6 +141,10 @@ public class GHService {
             LOG.info("Skipping forking plugin {} in dry-run mode", plugin);
             return;
         }
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping forking plugin {} in fetch-metadata-only mode", plugin);
+            return;
+        }
         if (plugin.isArchived(this)) {
             LOG.info("Plugin {} is archived. Not forking", plugin);
             return;
@@ -286,6 +290,10 @@ public class GHService {
             LOG.info("Skipping sync plugin {} in dry-run mode", plugin);
             return;
         }
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping sync plugin {} in fetch-metadata-only mode", plugin);
+            return;
+        }
         if (!isForked(plugin)) {
             LOG.info("Plugin {} is not forked. Not attempting sync", plugin);
             return;
@@ -314,6 +322,10 @@ public class GHService {
     public void deleteFork(Plugin plugin) {
         if (config.isDryRun()) {
             LOG.info("Skipping delete fork for plugin {} in dry-run mode", plugin);
+            return;
+        }
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping delete for for plugin {} in fetch-metadata-only mode", plugin);
             return;
         }
         if (!isForked(plugin)) {
@@ -480,6 +492,10 @@ public class GHService {
             LOG.info("Skipping push changes for plugin {} in dry-run mode", plugin);
             return;
         }
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping push changes for plugin {} in fetch-metadata-only mode", plugin);
+            return;
+        }
         if (config.isSkipPush()) {
             LOG.info("Skipping push changes for plugin {}", plugin);
             return;
@@ -513,6 +529,10 @@ public class GHService {
     public void openPullRequest(Plugin plugin) {
         if (config.isDryRun()) {
             LOG.info("Skipping pull request changes for plugin {} in dry-run mode", plugin);
+            return;
+        }
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping pull request for plugin {} in fetch-metadata-only mode", plugin);
             return;
         }
         if (config.isSkipPullRequest() || config.isSkipPush()) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -104,7 +104,9 @@ public class CacheManager {
                 }
             }
             LOG.debug("Cache entry found for cache {} at path {} and key {}", location, path, cacheKey);
-            return JsonUtils.fromJson(cachedPath, clazz);
+            T entry = JsonUtils.fromJson(cachedPath, clazz);
+            entry.setCacheManager(this);
+            return entry;
         } catch (IOException e) {
             LOG.debug("Cache entry not found for cache {} at path {} and key {}", location, path, cacheKey);
             return null;
@@ -120,11 +122,23 @@ public class CacheManager {
         try {
             if (Files.exists(fileToRemove)) {
                 Files.delete(fileToRemove);
-                LOG.debug("Cache entry removed for key: {}", cacheKey);
+                LOG.debug("Cache entry removed for key: {} at location {}", cacheKey, location);
             }
         } catch (IOException e) {
             throw new ModernizerException("Failed to remove cache entry for key: " + cacheKey, e);
         }
+    }
+
+    /**
+     * Move a cache entry to the new cache manager
+     * @param cacheManager The cache manager
+     * @param newPath The new path
+     * @param newKey The new key
+     * @param entry The cache entry to move
+     */
+    public <T extends CacheEntry<T>> T move(
+            CacheManager cacheManager, Path newPath, String newKey, CacheEntry<T> entry) {
+        return entry.move(cacheManager, newPath, newKey);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
@@ -105,6 +105,7 @@ public abstract class CacheEntry<T extends CacheEntry<T>> implements Serializabl
         refreshedObject.setKey(newKey);
         refreshedObject.setCacheManager(newCacheManager);
         newCacheManager.put(refreshedObject);
+        LOG.debug(refreshedObject.getCacheManager().getLocation().toString());
         this.delete();
         return newCacheManager.get(newPath, newKey, clazz);
     }
@@ -154,8 +155,8 @@ public abstract class CacheEntry<T extends CacheEntry<T>> implements Serializabl
      * Return the absolute path of the object
      * @return The absolute path
      */
-    public final Path getAbsolutePath() {
-        return cacheManager.getLocation().resolve(path);
+    public final Path getLocation() {
+        return cacheManager.getLocation().resolve(path).resolve(key);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -381,6 +381,10 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void compile(MavenInvoker maven) {
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping compilation for plugin {} as only metadata is required", name);
+            return;
+        }
         LOG.info(
                 "Compiling plugin {} with JDK {} ... Please be patient",
                 name,
@@ -396,6 +400,10 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void verify(MavenInvoker maven) {
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping verification for plugin {} as only metadata is required", name);
+            return;
+        }
         LOG.info(
                 "Verifying plugin {} with JDK {}... Please be patient",
                 name,
@@ -429,6 +437,10 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void runOpenRewrite(MavenInvoker maven) {
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping OpenRewrite recipe application for plugin {} as only metadata is required", name);
+            return;
+        }
         maven.invokeRewrite(this);
     }
 
@@ -437,6 +449,10 @@ public class Plugin {
      * @param service The GitHub service
      */
     public void fork(GHService service) {
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping fork for plugin {} as only metadata is required", name);
+            return;
+        }
         service.fork(this);
     }
 
@@ -445,6 +461,10 @@ public class Plugin {
      * @param service The GitHub service
      */
     public void sync(GHService service) {
+        if (config.isFetchMetadataOnly()) {
+            LOG.info("Skipping sync for plugin {} as only metadata is required", name);
+            return;
+        }
         service.sync(this);
     }
 


### PR DESCRIPTION
Optimize Metadata fetch by skiping fork, sync, compile and verification in this mode activated when only the fetch recipe is activated

Fix https://github.com/jenkinsci/plugin-modernizer-tool/issues/207

### Testing done

Automated tests and check logs on runtime

```
Skipping push changes for plugin asm-api in fetch-metadata-only mode
Skipping pull request for plugin asm-api in fetch-metadata-only mode
No changes to commit for plugin asm-api
Skipping push changes for plugin asm-api in fetch-metadata-only mode
Skipping pull request for plugin asm-api in fetch-metadata-only mode
*************
Plugin: asm-api
Metadata was fetched for plugin asm-api and is available at ~/.cache/jenkins-plugin-modernizer-cli/asm-api/plugin-metadata
*************
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
