### PR TITLE
Use types as early as possible to prevent issues about type conversion

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/CommaSeparatedParameterConsumer.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/CommaSeparatedParameterConsumer.java
@@ -15,6 +15,8 @@ public class CommaSeparatedParameterConsumer implements IParameterConsumer {
         for (String item : value.split(",", -1)) {
             result.add(item.trim());
         }
-        argSpec.setValue(result);
+        if (!result.isEmpty()) {
+            argSpec.setValue(result);
+        }
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -1,9 +1,11 @@
 package io.jenkins.tools.pluginmodernizer.core.config;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
+import org.openrewrite.Recipe;
 
 public class Config {
 
@@ -11,8 +13,8 @@ public class Config {
     public static boolean DEBUG = false;
 
     private final String version;
-    private final List<String> pluginNames;
-    private final List<String> recipes;
+    private final List<Plugin> plugins;
+    private final List<Recipe> recipes;
     private final URL jenkinsUpdateCenter;
     private final Path cachePath;
     private final Path mavenHome;
@@ -27,8 +29,8 @@ public class Config {
     private Config(
             String version,
             String githubOwner,
-            List<String> pluginNames,
-            List<String> recipes,
+            List<Plugin> plugins,
+            List<Recipe> recipes,
             URL jenkinsUpdateCenter,
             Path cachePath,
             Path mavenHome,
@@ -40,7 +42,7 @@ public class Config {
             boolean exportDatatables) {
         this.version = version;
         this.githubOwner = githubOwner;
-        this.pluginNames = pluginNames;
+        this.plugins = plugins;
         this.recipes = recipes;
         this.jenkinsUpdateCenter = jenkinsUpdateCenter;
         this.cachePath = cachePath;
@@ -61,11 +63,11 @@ public class Config {
         return githubOwner;
     }
 
-    public List<String> getPluginNames() {
-        return pluginNames;
+    public List<Plugin> getPlugins() {
+        return plugins;
     }
 
-    public List<String> getRecipes() {
+    public List<Recipe> getRecipes() {
         return recipes;
     }
 
@@ -74,7 +76,7 @@ public class Config {
      * @return True if only fetching metadata
      */
     public boolean isFetchMetadataOnly() {
-        return recipes.size() == 1 && recipes.get(0).equals(Settings.FETCH_METADATA_RECIPE.getName());
+        return recipes.size() == 1 && recipes.get(0).getName().equals(Settings.FETCH_METADATA_RECIPE.getName());
     }
 
     public URL getJenkinsUpdateCenter() {
@@ -124,8 +126,8 @@ public class Config {
     public static class Builder {
         private String version;
         private String githubOwner = Settings.GITHUB_OWNER;
-        private List<String> plugins;
-        private List<String> recipes;
+        private List<Plugin> plugins;
+        private List<Recipe> recipes;
         private URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
@@ -146,12 +148,12 @@ public class Config {
             return this;
         }
 
-        public Builder withPlugins(List<String> plugins) {
+        public Builder withPlugins(List<Plugin> plugins) {
             this.plugins = plugins;
             return this;
         }
 
-        public Builder withRecipes(List<String> recipes) {
+        public Builder withRecipes(List<Recipe> recipes) {
             this.recipes = recipes;
             return this;
         }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -26,6 +26,7 @@ import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
+import org.openrewrite.Recipe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -557,7 +558,10 @@ public class GHService {
         }
 
         // TODO: Update PR body to give more details
-        String prBody = String.format("Applied the following recipes: %s", String.join(", ", config.getRecipes()));
+        String prBody = String.format(
+                "Applied the following recipes: %s",
+                String.join(
+                        ", ", config.getRecipes().stream().map(Recipe::getName).toList()));
         try {
             GHPullRequest pr = repository.createPullRequest(
                     PR_TITLE, config.getGithubOwner() + ":" + BRANCH_NAME, repository.getDefaultBranch(), prBody);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -53,7 +53,7 @@ public class PluginModernizer {
         cacheManager.init();
 
         // Debug config
-        LOG.debug("Plugins: {}", config.getPluginNames());
+        LOG.debug("Plugins: {}", config.getPlugins());
         LOG.debug("Recipes: {}", config.getRecipes());
         LOG.debug("GitHub owner: {}", config.getGithubOwner());
         LOG.debug("Update Center Url: {}", config.getJenkinsUpdateCenter());
@@ -63,8 +63,7 @@ public class PluginModernizer {
         LOG.debug("Skip Pull Request: {}", config.isSkipPullRequest());
         LOG.debug("Maven rewrite plugin version: {}", Settings.MAVEN_REWRITE_PLUGIN_VERSION);
 
-        List<Plugin> plugins =
-                config.getPluginNames().stream().map(Plugin::build).toList();
+        List<Plugin> plugins = config.getPlugins();
         plugins.forEach(this::process);
         printResults(plugins);
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.github.GHRepository;
@@ -585,5 +586,18 @@ public class Plugin {
     @Override
     public String toString() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Plugin plugin = (Plugin) o;
+        return Objects.equals(name, plugin.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
     }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
@@ -5,13 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openrewrite.Recipe;
 
 public class ConfigTest {
 
@@ -19,8 +23,11 @@ public class ConfigTest {
     public void testConfigBuilderWithAllFields() throws MalformedURLException {
         String version = "1.0";
         String githubOwner = "test-owner";
-        List<String> plugins = Arrays.asList("plugin1", "plugin2");
-        List<String> recipes = Arrays.asList("recipe1", "recipe2");
+        List<Plugin> plugins =
+                Stream.of("plugin1", "plugin2").map(Plugin::build).toList();
+        List<Recipe> recipes = Arrays.asList(Mockito.mock(Recipe.class), Mockito.mock(Recipe.class));
+        Mockito.doReturn("recipe1").when(recipes.get(0)).getName();
+        Mockito.doReturn("recipe2").when(recipes.get(1)).getName();
         URL jenkinsUpdateCenter = new URL("https://updates.jenkins.io/current/update-center.actual.json");
         Path cachePath = Paths.get("/path/to/cache");
         Path mavenHome = Paths.get("/path/to/maven");
@@ -44,7 +51,7 @@ public class ConfigTest {
 
         assertEquals(version, config.getVersion());
         assertEquals(githubOwner, config.getGithubOwner());
-        assertEquals(plugins, config.getPluginNames());
+        assertEquals(plugins, config.getPlugins());
         assertEquals(recipes, config.getRecipes());
         assertEquals(jenkinsUpdateCenter, config.getJenkinsUpdateCenter());
         assertEquals(cachePath, config.getCachePath());
@@ -63,7 +70,7 @@ public class ConfigTest {
         Config config = Config.builder().build();
 
         assertNull(config.getVersion());
-        assertNull(config.getPluginNames());
+        assertNull(config.getPlugins());
         assertNull(config.getRecipes());
         assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
@@ -80,13 +87,14 @@ public class ConfigTest {
     @Test
     public void testConfigBuilderWithPartialValues() {
         String version = "2.0";
-        List<String> plugins = Arrays.asList("plugin1", "plugin2");
+        List<Plugin> plugins =
+                Stream.of("plugin1", "plugin2").map(Plugin::build).toList();
 
         Config config =
                 Config.builder().withVersion(version).withPlugins(plugins).build();
 
         assertEquals(version, config.getVersion());
-        assertEquals(plugins, config.getPluginNames());
+        assertEquals(plugins, config.getPlugins());
         assertNull(config.getRecipes());
         assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
@@ -103,7 +111,7 @@ public class ConfigTest {
                 .build();
 
         assertNull(config.getVersion());
-        assertNull(config.getPluginNames());
+        assertNull(config.getPlugins());
         assertNull(config.getRecipes());
         assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());


### PR DESCRIPTION
Use `Plugin` and `Recipe` types as CLI argument. Will also validate recipe name as soon as possible (And not anymore on the `MavenInvoker`

I also made `--plugins` and `--plugin-file` mutually exclusive

For the recipe the FQDN and short name are both accepted

Should fix issue on https://github.com/jenkinsci/plugin-modernizer-tool/issues/207

### Testing done

Automated tests 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

