### PR TITLE
Use JDK from metadata if possible

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -209,6 +209,26 @@ public enum JDK {
     }
 
     /**
+     * Return the minimum JDK from a list of JDKs
+     * @param jdks List of JDKS. Can be null or empty
+     * @return The minimum JDK. If the list is empty, return the minimum JDK available
+     */
+    public static JDK min(List<JDK> jdks) {
+        if (jdks == null || jdks.isEmpty()) {
+            return JDK.min();
+        }
+        return jdks.stream().min(JDK::compareMajor).orElseThrow();
+    }
+
+    /**
+     * Return a list of all JDK sorted by major version
+     * @return The list of JDKs
+     */
+    public static List<JDK> all() {
+        return Arrays.stream(values()).sorted(JDK::compareMajor).toList();
+    }
+
+    /**
      * Get list of buildable JDKs for a given Jenkins version
      * @param jenkinsVersion The Jenkins version
      * @return The list of buildable JDKs

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -39,6 +39,15 @@ public class JDKTest {
     }
 
     @Test
+    public void all() {
+        assertEquals(4, JDK.all().size());
+        assertEquals(JDK.JAVA_8, JDK.all().get(0));
+        assertEquals(JDK.JAVA_11, JDK.all().get(1));
+        assertEquals(JDK.JAVA_17, JDK.all().get(2));
+        assertEquals(JDK.JAVA_21, JDK.all().get(3));
+    }
+
+    @Test
     public void getBuildableJdk() {
 
         assertEquals(1, JDK.get("2.163").size());


### PR DESCRIPTION
This also simplify the PluginModernizer flow

- We don't compile the plugin if we don't have metadata
- Create local metadata or get them from cache if present
- We run the recipe 
- We verify the plugin (including tests)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
