### PR TITLE
Add static preconditions for pom.xml

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -117,6 +117,12 @@ public class PluginModernizer {
 
             plugin.checkoutBranch(ghService);
 
+            // Ensure minimum baseline of JDK 8.
+            // For the moment some plugin cannot be refreshed due to some condition
+            // (Non HTTPS URL, java 7 build). For those plugin we will fail until we find a solution
+            LOG.info("Checking if plugin {} can be modernized", plugin.getName());
+            plugin.ensureMinimalBuild(mavenInvoker);
+
             // Minimum JDK to run openrewrite
             plugin.withJDK(JDK.JAVA_17);
 


### PR DESCRIPTION
An improvement would be to store metadata with those failing details. So that we can identify plugin that require (manual ?) fix because they are so outdated

At least now the error is more meaningful

### Testing done

Didn't write test for now, but did some interfactive tests

![error2](https://github.com/user-attachments/assets/e339eef5-5daa-4673-aa33-d7151a55f89d)
![error](https://github.com/user-attachments/assets/7094e1cf-3bff-48dc-a1e6-0b7da970edcf)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
