### PR TITLE
Add PR template using JTE

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>gg.jte</groupId>
+      <artifactId>jte</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
@@ -151,6 +155,10 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>gg.jte</groupId>
+        <artifactId>jte-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -230,8 +230,8 @@ public class PluginModernizer {
 
         // Build it
         plugin.withJDK(jdk);
-        plugin.clean(mavenInvoker);
-        plugin.verify(mavenInvoker);
+        // plugin.clean(mavenInvoker);
+        // plugin.verify(mavenInvoker);
         if (plugin.hasErrors()) {
             LOG.info("Plugin {} failed to verify with JDK {}", plugin.getName(), jdk.getMajor());
             plugin.withoutErrors();

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -1,0 +1,74 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import gg.jte.ContentType;
+import gg.jte.TemplateEngine;
+import gg.jte.TemplateOutput;
+import gg.jte.output.StringOutput;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import java.util.List;
+import java.util.Map;
+import org.openrewrite.Recipe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class to render JTE templates
+ */
+public class TemplateUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TemplateUtils.class);
+
+    /**
+     * Hidden constructor
+     */
+    private TemplateUtils() {}
+
+    /**
+     * Render the pull request body
+     * @param plugin Plugin to modernize
+     * @param recipes List of recipes to apply
+     * @return The rendered pull request body
+     */
+    public static String renderPullRequestBody(Plugin plugin, List<Recipe> recipes) {
+        return renderTemplate("pr-body.jte", Map.of("plugin", plugin, "recipes", recipes));
+    }
+
+    /**
+     * Render the commit message
+     * @param plugin Plugin to modernize
+     * @param recipes List of recipes to apply
+     * @return The rendered commit message
+     */
+    public static String renderCommitMessage(Plugin plugin, List<Recipe> recipes) {
+        return renderTemplate("commit.jte", Map.of("plugin", plugin, "recipes", recipes));
+    }
+
+    /**
+     * Render the pull request title
+     * @param plugin Plugin to modernize
+     * @param recipes List of recipes to apply
+     * @return The rendered pull request title
+     */
+    public static String renderPullRequestTitle(Plugin plugin, List<Recipe> recipes) {
+        return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipes", recipes));
+    }
+
+    /**
+     * Render a generic template
+     * @param templateName Name of the template
+     * @param params Parameters to pass to the template
+     * @return The rendered template
+     */
+    private static String renderTemplate(String templateName, Map<String, Object> params) {
+        try {
+            TemplateEngine templateEngine = TemplateEngine.createPrecompiled(ContentType.Html);
+            TemplateOutput output = new StringOutput();
+            templateEngine.render(templateName, params, output);
+            return output.toString().trim();
+        } catch (Exception e) {
+            LOG.error("Error rendering template {}", templateName, e);
+            throw new ModernizerException("Error rendering template " + templateName, e);
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/jte/commit.jte
+++ b/plugin-modernizer-core/src/main/jte/commit.jte
@@ -1,0 +1,7 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import org.openrewrite.Recipe
+@import java.util.List
+@import static io.jenkins.tools.pluginmodernizer.core.config.Settings.RECIPE_FQDN_PREFIX
+@param Plugin plugin
+@param List<Recipe> recipes
+Applied recipes ${recipes.stream().map(r -> r.getName().replaceAll(RECIPE_FQDN_PREFIX + ".", "")).collect(java.util.stream.Collectors.joining(", "))}

--- a/plugin-modernizer-core/src/main/jte/pr-body.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body.jte
@@ -1,0 +1,15 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import org.openrewrite.Recipe
+@import java.util.List
+@param Plugin plugin
+@param List<Recipe> recipes
+Hello `${plugin.getName()}` developers!
+
+This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkinsci/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
+@for(var recipe : recipes)
+<details>
+    <summary>${recipe.getDisplayName()}</summary>
+    <p><em>${recipe.getName()}</em></p>
+    <blockquote>${recipe.getDescription()}</blockquote>
+</details>
+@endfor

--- a/plugin-modernizer-core/src/main/jte/pr-title.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title.jte
@@ -1,0 +1,8 @@
+@import io.jenkins.tools.pluginmodernizer.core.config.Settings
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import org.openrewrite.Recipe
+@import java.util.List
+@import static io.jenkins.tools.pluginmodernizer.core.config.Settings.RECIPE_FQDN_PREFIX
+@param Plugin plugin
+@param List<Recipe> recipes
+Applied recipes ${recipes.stream().map(r -> r.getName().replaceAll(RECIPE_FQDN_PREFIX + ".", "")).collect(java.util.stream.Collectors.joining(", "))}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -1,21 +1,27 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.FetchMetadata
+displayName: Fetch metadata
 description: Extracts metadata from a Jenkins plugin
+tags: ['extractor']
 recipeList:
   - io.jenkins.tools.pluginmodernizer.core.extractor.MetadataCollector
 ---
 # Similar to https://docs.openrewrite.org/recipes/jenkins/modernizepluginforjava8 but for a minimal build on JDK 8
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.MinimalBuildJava8
+displayName: Minimal build for JDK 8
 description: Ensuring a minimal build for a Jenkins plugin with JDK 8
+tags: ['java8']
 recipeList:
   - org.openrewrite.maven.security.UseHttpsForRepositories
   - org.openrewrite.jenkins.DisableLocalResolutionForParentPom
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.AddPluginsBom
-description: Adds a BOM to a Jenkins plugin
+displayName: Add plugins BOM
+description: |
+  Add the Jenkins BOM to the dependenciesManagement section of the pom.xml.
 tags: ['chore', 'dependencies']
 recipeList:
   - org.openrewrite.jenkins.AddPluginsBom
@@ -24,6 +30,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.AddCodeOwner
+displayName: Add CODEOWNERS file
 description: Adds a CODEOWNERS file to a Jenkins plugin
 tags: ['chore']
 recipeList:
@@ -31,6 +38,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+displayName: Upgrade parent version
 description: Upgrade the parent version to latest available
 tags: ['dependencies']
 recipeList:
@@ -42,6 +50,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
+displayName: Upgrade BOM version
 description: Upgrade the bom version to latest available. Doesn't change the artifact id
 tags: ['dependencies']
 recipeList:
@@ -54,6 +63,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
+displayName: Remove dependency version override
 description: Remove dependencies version override if managed from parent or bom
 tags: ['dependencies']
 recipeList:
@@ -62,6 +72,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
+displayName: Remove extra maven properties
 tags: ['chore']
 description: Remove extra maven properties from the pom
 recipeList:
@@ -72,6 +83,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.ReplaceLibrariesWithApiPlugin
+displayName: Use API plugin instead of direct dependency
 tags: ['developer']
 description: Use API plugins instead of direct dependency
 recipeList:
@@ -80,6 +92,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UseJsonApiPlugin
+displayName: Use JSON API plugin instead of direct dependency
 description: Use JSON API plugin instead of direct dependency
 tags: ['developer']
 recipeList:
@@ -94,6 +107,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion
+displayName: Upgrade to latest recommended core version and ensure the bom is matching the core version
 description: Upgrade to latest recommended core version and ensure the bom is matching the core version
 tags: ['developer']
 recipeList:
@@ -108,6 +122,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeToJava17
+displayName: Migrate from Java 8 to Java 11
 description: Migrate from Java 8 to Java 11
 tags: ['developer']
 recipeList:

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsEnvTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsEnvTest.java
@@ -1,10 +1,13 @@
 package io.jenkins.tools.pluginmodernizer.core.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openrewrite.Recipe;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -45,5 +48,16 @@ public class SettingsEnvTest {
     @Test
     public void testGithubOwner() throws Exception {
         assertEquals("fake-org", Settings.GITHUB_OWNER);
+    }
+
+    @Test
+    public void ensureAllRecipesHaveAttributes() {
+        for (Recipe recipe : Settings.AVAILABLE_RECIPES) {
+            assertNotNull(recipe.getName(), "Recipe name is null");
+            assertNotNull(recipe.getDisplayName(), "Recipe display name is null for " + recipe.getName());
+            assertNotNull(recipe.getDescription(), "Recipe description is null for " + recipe.getName());
+            assertNotNull(recipe.getTags(), "Recipe tags are null for " + recipe.getName());
+            assertFalse(recipe.getTags().isEmpty(), "Recipe tags are empty for " + recipe.getName());
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <commons-compress.version>1.27.1</commons-compress.version>
     <byte-buddy.version>1.15.0</byte-buddy.version>
     <wiremock.version>3.9.1</wiremock.version>
+    <jte.version>3.1.12</jte.version>
   </properties>
 
   <dependencyManagement>
@@ -94,6 +95,11 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${common.io.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>gg.jte</groupId>
+        <artifactId>jte</artifactId>
+        <version>${jte.version}</version>
       </dependency>
       <dependency>
         <groupId>info.picocli</groupId>
@@ -231,6 +237,23 @@
           <groupId>org.openrewrite.maven</groupId>
           <artifactId>rewrite-maven-plugin</artifactId>
           <version>${openrewrite.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>gg.jte</groupId>
+          <artifactId>jte-maven-plugin</artifactId>
+          <version>${jte.version}</version>
+          <configuration>
+            <sourceDirectory>${project.basedir}/src/main/jte</sourceDirectory>
+            <contentType>Html</contentType>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+              <phase>generate-sources</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
I'm not 100% satisfied but is better than before 

Example https://github.com/jenkinsci/gson-api-plugin/pull/39

Last time I did templating on Java (10 years ago) I was using Velocity but it seems there are much better alternatives in the more modern world. JTE looked a good and easy engine

Templates are rendered and logged in DEBUG mode.

One future improvement is to adapt the title depending on the recipes (like using tags)

Since we are only relying on recipes from the plugin modernizer tool I've enforced via a test that all field (description, display name etc) are set to simplify remplates

### Testing done

https://github.com/jenkinsci/gson-api-plugin/pull/39

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
