### PR TITLE
Fetch health score data for each plugin

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -121,6 +121,12 @@ public class Main implements Runnable {
     public URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
 
     @Option(
+            names = "--plugin-health-score",
+            description =
+                    "Sets the plugin health score URL; will override JENKINS_PHS environment variable. If not set via CLI option or environment variable, will use default health score url.")
+    public URL pluginHealthScore = Settings.DEFAULT_HEALTH_SCORE_URL;
+
+    @Option(
             names = {"-c", "--cache-path"},
             description = "Path to the cache directory.")
     public Path cachePath = Settings.DEFAULT_CACHE_PATH;
@@ -150,6 +156,7 @@ public class Main implements Runnable {
                 .withRemoveForks(removeForks)
                 .withExportDatatables(exportDatatables)
                 .withJenkinsUpdateCenter(jenkinsUpdateCenter)
+                .withPluginHealthScore(pluginHealthScore)
                 .withCachePath(cachePath)
                 .withMavenHome(mavenHome)
                 .build();

--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -135,7 +135,7 @@
         <directory>src/main/resources</directory>
         <includes>
           <include>versions.properties</include>
-          <include>update_center.properties</include>
+          <include>urls.properties</include>
         </includes>
       </resource>
       <resource>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -16,6 +16,7 @@ public class Config {
     private final List<Plugin> plugins;
     private final List<Recipe> recipes;
     private final URL jenkinsUpdateCenter;
+    private final URL pluginHealthScore;
     private final Path cachePath;
     private final Path mavenHome;
     private final boolean dryRun;
@@ -32,6 +33,7 @@ public class Config {
             List<Plugin> plugins,
             List<Recipe> recipes,
             URL jenkinsUpdateCenter,
+            URL pluginHealthScore,
             Path cachePath,
             Path mavenHome,
             boolean dryRun,
@@ -45,6 +47,7 @@ public class Config {
         this.plugins = plugins;
         this.recipes = recipes;
         this.jenkinsUpdateCenter = jenkinsUpdateCenter;
+        this.pluginHealthScore = pluginHealthScore;
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
         this.dryRun = dryRun;
@@ -81,6 +84,10 @@ public class Config {
 
     public URL getJenkinsUpdateCenter() {
         return jenkinsUpdateCenter;
+    }
+
+    public URL getPluginHealthScore() {
+        return pluginHealthScore;
     }
 
     public Path getCachePath() {
@@ -129,6 +136,7 @@ public class Config {
         private List<Plugin> plugins;
         private List<Recipe> recipes;
         private URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
+        private URL pluginHealthScore = Settings.DEFAULT_HEALTH_SCORE_URL;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
         private boolean dryRun = false;
@@ -161,6 +169,13 @@ public class Config {
         public Builder withJenkinsUpdateCenter(URL jenkinsUpdateCenter) {
             if (jenkinsUpdateCenter != null) {
                 this.jenkinsUpdateCenter = jenkinsUpdateCenter;
+            }
+            return this;
+        }
+
+        public Builder withPluginHealthScore(URL pluginHealthScore) {
+            if (pluginHealthScore != null) {
+                this.pluginHealthScore = pluginHealthScore;
             }
             return this;
         }
@@ -216,6 +231,7 @@ public class Config {
                     plugins,
                     recipes,
                     jenkinsUpdateCenter,
+                    pluginHealthScore,
                     cachePath,
                     mavenHome,
                     dryRun,

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -24,6 +24,8 @@ public class Settings {
 
     public static final URL DEFAULT_UPDATE_CENTER_URL;
 
+    public static final URL DEFAULT_HEALTH_SCORE_URL;
+
     public static final Path DEFAULT_CACHE_PATH;
 
     public static final Path DEFAULT_MAVEN_HOME;
@@ -76,6 +78,11 @@ public class Settings {
         } catch (MalformedURLException e) {
             throw new ModernizerException("Invalid URL format", e);
         }
+        try {
+            DEFAULT_HEALTH_SCORE_URL = getHealthScoreUrl();
+        } catch (MalformedURLException e) {
+            throw new ModernizerException("Invalid URL format", e);
+        }
 
         // Get recipes module
         try (InputStream inputStream = Settings.class.getResourceAsStream("/" + Settings.RECIPE_DATA_YAML_PATH)) {
@@ -120,7 +127,15 @@ public class Settings {
         if (url != null) {
             return new URL(url);
         }
-        return new URL(readProperty("update.center.url", "update_center.properties"));
+        return new URL(readProperty("update.center.url", "urls.properties"));
+    }
+
+    private static @Nullable URL getHealthScoreUrl() throws MalformedURLException {
+        String url = System.getenv("JENKINS_PHS");
+        if (url != null) {
+            return new URL(url);
+        }
+        return new URL(readProperty("plugin.health.score.url", "urls.properties"));
     }
 
     private static String getGithubToken() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -16,6 +16,7 @@ public class CacheManager {
 
     // Cache keys
     public static final String UPDATE_CENTER_CACHE_KEY = "update-center";
+    public static final String HEALTH_SCORE_KEY = "health-score";
     public static final String PLUGIN_METADATA_CACHE_KEY = "plugin-metadata";
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheManager.class);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -8,6 +8,7 @@ import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.model.JDK;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
+import io.jenkins.tools.pluginmodernizer.core.utils.HealthScoreUtils;
 import io.jenkins.tools.pluginmodernizer.core.utils.JdkFetcher;
 import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterUtils;
 import java.nio.file.Path;
@@ -59,6 +60,7 @@ public class PluginModernizer {
                 "Recipes: {}", config.getRecipes().stream().map(Recipe::getName).collect(Collectors.joining(", ")));
         LOG.debug("GitHub owner: {}", config.getGithubOwner());
         LOG.debug("Update Center Url: {}", config.getJenkinsUpdateCenter());
+        LOG.debug("Plugin Health Score Url: {}", config.getPluginHealthScore());
         LOG.debug("Cache Path: {}", config.getCachePath());
         LOG.debug("Dry Run: {}", config.isDryRun());
         LOG.debug("Skip Push: {}", config.isSkipPush());
@@ -82,6 +84,11 @@ public class PluginModernizer {
 
             // Determine repo name
             plugin.withRepositoryName(UpdateCenterUtils.extractRepoName(plugin, cacheManager));
+
+            LOG.info(
+                    "Plugin {} health score: {}",
+                    plugin.getName(),
+                    HealthScoreUtils.extractScore(plugin, cacheManager));
 
             if (config.isRemoveForks()) {
                 plugin.deleteFork(ghService);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/HealthScoreData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/HealthScoreData.java
@@ -1,0 +1,36 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Data from the update center
+ * We are storing only the data we are interested in (like plugins).
+ * Further implementation can consider ignoring plugin with deprecation
+ */
+public class HealthScoreData extends CacheEntry<HealthScoreData> implements Serializable {
+
+    /**
+     * Plugins in the health score mapped by their name
+     */
+    private Map<String, HealthScorePlugin> plugins;
+
+    public HealthScoreData(CacheManager cacheManager) {
+        super(cacheManager, HealthScoreData.class, CacheManager.HEALTH_SCORE_KEY, Path.of("."));
+    }
+
+    /**
+     * Get the plugins
+     * @return Plugins
+     */
+    public Map<String, HealthScorePlugin> getPlugins() {
+        return plugins;
+    }
+
+    /**
+     * A health score plugin record with what we need
+     */
+    public record HealthScorePlugin(Double value) implements Serializable {}
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/HealthScoreUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/HealthScoreUtils.java
@@ -1,0 +1,61 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import io.jenkins.tools.pluginmodernizer.core.model.HealthScoreData;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for Health Score
+ */
+public class HealthScoreUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HealthScoreUtils.class);
+
+    /**
+     * Extract the score for a plugin
+     * @param plugin Plugin
+     * @param cacheManager Cache manager
+     * @return Score
+     */
+    public static Double extractScore(Plugin plugin, CacheManager cacheManager) {
+        HealthScoreData healthScoreData = get(plugin.getConfig(), cacheManager);
+        HealthScoreData.HealthScorePlugin healthScorePlugin =
+                healthScoreData.getPlugins().get(plugin.getName());
+        if (healthScorePlugin == null) {
+            plugin.addError("Plugin not found in health score data: " + plugin.getName());
+            plugin.raiseLastError();
+            return null;
+        }
+        return healthScorePlugin.value();
+    }
+
+    /**
+     * Retrieve health score data from the given URL of from cache if it exists
+     * @param cacheManager Cache manager
+     * @return Health score data
+     */
+    public static HealthScoreData get(Config config, CacheManager cacheManager) {
+        HealthScoreData healthScoreData =
+                cacheManager.get(cacheManager.root(), CacheManager.HEALTH_SCORE_KEY, HealthScoreData.class);
+        // Download and update cache
+        if (healthScoreData == null) {
+            healthScoreData = download(config);
+            healthScoreData.setKey(CacheManager.HEALTH_SCORE_KEY);
+            healthScoreData.setPath(cacheManager.root());
+            cacheManager.put(healthScoreData);
+        }
+        return healthScoreData;
+    }
+
+    /**
+     * Download refreshed update center data from the remote service
+     * @param config Configuration
+     * @return Update center data
+     */
+    public static HealthScoreData download(Config config) {
+        return JsonUtils.fromUrl(config.getPluginHealthScore(), HealthScoreData.class);
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/UpdateCenterUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/UpdateCenterUtils.java
@@ -1,16 +1,10 @@
 package io.jenkins.tools.pluginmodernizer.core.utils;
 
-import com.google.gson.JsonSyntaxException;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.UpdateCenterData;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,21 +63,6 @@ public class UpdateCenterUtils {
      * @return Update center data
      */
     public static UpdateCenterData download(Config config) {
-        try {
-            HttpClient client = HttpClient.newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder()
-                    .GET()
-                    .uri(config.getJenkinsUpdateCenter().toURI())
-                    .build();
-            LOG.debug("Fetching update center data from: {}", config.getJenkinsUpdateCenter());
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() != 200) {
-                throw new ModernizerException("Failed to fetch update center data: " + response.statusCode());
-            }
-            LOG.debug("Fetched update center data from: {}", config.getJenkinsUpdateCenter());
-            return JsonUtils.fromJson(response.body(), UpdateCenterData.class);
-        } catch (IOException | JsonSyntaxException | URISyntaxException | InterruptedException e) {
-            throw new ModernizerException("Unable to fetch update center data", e);
-        }
+        return JsonUtils.fromUrl(config.getJenkinsUpdateCenter(), UpdateCenterData.class);
     }
 }

--- a/plugin-modernizer-core/src/main/resources/urls.properties
+++ b/plugin-modernizer-core/src/main/resources/urls.properties
@@ -1,1 +1,2 @@
 update.center.url=https://updates.jenkins.io/current/update-center.actual.json
+plugin.health.score.url=https://plugin-health.jenkins.io/api/scores

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/HealthScoreUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/HealthScoreUtilsTest.java
@@ -1,0 +1,87 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import io.jenkins.tools.pluginmodernizer.core.model.HealthScoreData;
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({MockitoExtension.class})
+@WireMockTest
+public class HealthScoreUtilsTest {
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private Config config;
+
+    @Mock
+    private Path cacheRoot;
+
+    private HealthScoreData healthScoreData;
+
+    @BeforeEach
+    public void setup() throws Exception {
+
+        healthScoreData = new HealthScoreData(cacheManager);
+
+        // Add plugins
+        Map<String, HealthScoreData.HealthScorePlugin> plugins = new HashMap<>();
+        plugins.put("valid-plugin", new HealthScoreData.HealthScorePlugin(100d));
+        plugins.put("valid-plugin2", new HealthScoreData.HealthScorePlugin(50d));
+
+        // Set plugins
+        Field field = ReflectionUtils.findFields(
+                        HealthScoreData.class,
+                        f -> f.getName().equals("plugins"),
+                        ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+                .get(0);
+        field.setAccessible(true);
+        field.set(healthScoreData, plugins);
+
+        // Return this update center from the cache
+        doReturn(healthScoreData)
+                .when(cacheManager)
+                .get(cacheRoot, CacheManager.HEALTH_SCORE_KEY, HealthScoreData.class);
+        doReturn(cacheRoot).when(cacheManager).root();
+    }
+
+    @Test
+    public void shouldDownload(WireMockRuntimeInfo wmRuntimeInfo) throws MalformedURLException {
+
+        // Download through wiremock to avoid hitting the real Jenkins update center
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/api/scores"))
+                .willReturn(WireMock.okJson(JsonUtils.toJson(healthScoreData))));
+
+        // No found from cache
+        doReturn(new URL(wmRuntimeInfo.getHttpBaseUrl() + "/api/scores"))
+                .when(config)
+                .getPluginHealthScore();
+
+        Mockito.reset(cacheManager);
+
+        // Get result
+        HealthScoreData result = HealthScoreUtils.download(config);
+        assertEquals(result.getPlugins().size(), healthScoreData.getPlugins().size());
+    }
+}


### PR DESCRIPTION
Fetch health score data for each plugin

### Testing done

One automated tests for the download (using wiremock)

And check the logs for some plugins

```
Fetching data from: https://plugin-health.jenkins.io/api/scores 
Fetched data from: https://plugin-health.jenkins.io/api/scores 
Plugin beaker-builder health score: 45.0 
Skipping fork for plugin beaker-builder as only metadata is required 
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
