### PR TITLE
Include bom version on metadata

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollector.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollector.java
@@ -252,6 +252,12 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
                 if (parent != null) {
                     pluginMetadata.setParentVersion(parent.getVersion());
                 }
+                // Lookup by group ID to set the BOM version if any
+                pom.getDependencyManagement().stream()
+                        .peek(dependency -> LOG.debug("Dependency: {}", dependency))
+                        .filter(dependency -> "io.jenkins.tools.bom".equals(dependency.getGroupId()))
+                        .findFirst()
+                        .ifPresent(dependency -> pluginMetadata.setBomVersion(dependency.getVersion()));
                 pluginMetadata.setProperties(properties);
                 pluginMetadata.setJenkinsVersion(
                         resolvedPom.getManagedVersion("org.jenkins-ci.main", "jenkins-core", null, null));

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -57,6 +57,11 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serial
     private String parentVersion;
 
     /**
+     * BOM version
+     */
+    private String bomVersion;
+
+    /**
      * Properties defined in the POM file of the plugin
      */
     private Map<String, String> properties;
@@ -186,6 +191,14 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serial
 
     public void setParentVersion(String parentVersion) {
         this.parentVersion = parentVersion;
+    }
+
+    public String getBomVersion() {
+        return bomVersion;
+    }
+
+    public void setBomVersion(String bomVersion) {
+        this.bomVersion = bomVersion;
     }
 
     public Map<String, String> getProperties() {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
@@ -153,6 +153,7 @@ public class MetadataCollectorTest implements RewriteTest {
         assertEquals("4.80", pluginMetadata.getParentVersion());
         String jenkinsVersion = pluginMetadata.getJenkinsVersion();
         assertEquals("2.426.3", jenkinsVersion);
+        assertEquals("2950.va_633b_f42f759", pluginMetadata.getBomVersion());
         assertNotNull(pluginMetadata.getProperties().get("java.level"));
         assertTrue(pluginMetadata.hasFlag(MetadataFlag.SCM_HTTPS));
         assertTrue(pluginMetadata.hasFlag(MetadataFlag.MAVEN_REPOSITORIES_HTTPS));


### PR DESCRIPTION
The BOM is a special artifact in the bom and probably deserve it's version stored on metadata like the parent pom

### Testing done

Add assertion on automated test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
