### PR TITLE
Compute again metadata after transformation

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -5,6 +5,7 @@ import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.time.Clock;
@@ -108,9 +109,11 @@ public class CacheManager {
             T entry = JsonUtils.fromJson(cachedPath, clazz);
             entry.setCacheManager(this);
             return entry;
-        } catch (IOException e) {
+        } catch (NoSuchFileException e) {
             LOG.debug("Cache entry not found for cache {} at path {} and key {}", location, path, cacheKey);
             return null;
+        } catch (IOException e) {
+            throw new ModernizerException("Failed to read cache entry for key: " + cacheKey, e);
         }
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
@@ -93,7 +93,7 @@ public class JsonUtils {
             LOG.debug("Fetching data from: {}", url);
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {
-                throw new ModernizerException("Failed to fetch health score: " + response.statusCode());
+                throw new ModernizerException("Failed to JSON data: " + response.statusCode());
             }
             LOG.debug("Fetched data from: {}", url);
             return JsonUtils.fromJson(response.body(), clazz);


### PR DESCRIPTION
The idea behind is to get refreshed data after modernization.

It could also be used to display some kind of diff on the summary or pull request

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
