### PR TITLE
chore(updatecli): Keep the main Dockerfile updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV JDK8_PACKAGE=8.0.422-tem
 ENV JDK11_PACKAGE=11.0.24-tem
 ENV JDK17_PACKAGE=17.0.12-tem
 ENV JDK21_PACKAGE=21.0.4-tem
+ENV MVN_INSTALL_PLUGIN_VERSION=3.1.2
 
 # Install respective JDK via SDK man
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN mvn org.apache.maven.plugins:maven-install-plugin:${MVN_INSTALL_PLUGIN_VERSI
     -Dpackaging=jar
 
 # Set the entry point for the Docker container
-ENTRYPOINT ["java", "-jar", "/jenkins-plugin-modernizer.jar"]do
+ENTRYPOINT ["java", "-jar", "/jenkins-plugin-modernizer.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
+# Use the official Maven image with Eclipse Temurin JDK 21
 FROM maven:3.9.9-eclipse-temurin-21
 
+# Update package lists and install necessary packages
 RUN apt-get update && \
     apt-get install -y curl zip unzip \
     && rm -rf /var/lib/apt/lists/*
 
+# Set environment variables for JDK versions managed by SDKMAN
 ENV JDK8_PACKAGE=8.0.422-tem
 ENV JDK11_PACKAGE=11.0.24-tem
 ENV JDK17_PACKAGE=17.0.12-tem
 ENV JDK21_PACKAGE=21.0.4-tem
 ENV MVN_INSTALL_PLUGIN_VERSION=3.1.2
 
-# Install respective JDK via SDK man
+# Install SDKMAN and respective JDKs
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN curl -s "https://get.sdkman.io" | bash
 RUN source "/root/.sdkman/bin/sdkman-init.sh" && \
@@ -19,18 +22,20 @@ RUN source "/root/.sdkman/bin/sdkman-init.sh" && \
     sdk install java $JDK17_PACKAGE && \
     sdk install java $JDK21_PACKAGE
 
+# Set the version for the plugin-modernizer
 ENV VERSION=999999-SNAPSHOT
 
-# Add jar
+# Add the plugin-modernizer JAR files to the image
 ADD plugin-modernizer-cli/target/jenkins-plugin-modernizer-${VERSION}.jar /jenkins-plugin-modernizer.jar
 ADD plugin-modernizer-core/target/plugin-modernizer-core-${VERSION}.jar /jenkins-plugin-modernizer-core.jar
 
-# Install core dependency
-RUN mvn org.apache.maven.plugins:maven-install-plugin:3.1.3:install-file  \
+# Install the core dependency using the Maven install plugin
+RUN mvn org.apache.maven.plugins:maven-install-plugin:${MVN_INSTALL_PLUGIN_VERSION}:install-file  \
     -Dfile=/jenkins-plugin-modernizer-core.jar \
     -DgroupId=io.jenkins.plugin-modernizer \
     -DartifactId=plugin-modernizer-core \
     -Dversion=${VERSION} \
     -Dpackaging=jar
 
-ENTRYPOINT ["java", "-jar", "/jenkins-plugin-modernizer.jar"]
+# Set the entry point for the Docker container
+ENTRYPOINT ["java", "-jar", "/jenkins-plugin-modernizer.jar"]do

--- a/updatecli/updatecli.d/maven-install.yaml
+++ b/updatecli/updatecli.d/maven-install.yaml
@@ -1,0 +1,58 @@
+---
+# This YAML configuration file is used by the updatecli tool to automate the process of updating the Maven install plugin version
+# in a Dockerfile. It defines the sources from which to retrieve the latest plugin version, the targets where this version should be applied,
+# and the actions to take upon successful updates.
+
+# Define the name of the updatecli configuration.
+name: Bump the Maven install tool up to date in the docker file
+
+# Define the source control management (SCM) configuration for GitHub.
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}" # The GitHub username to use for commits.
+      email: "{{ .github.email }}" # The email associated with the GitHub user.
+      owner: "{{ .github.owner }}" # The owner of the repository where changes will be made.
+      repository: "{{ .github.repository }}" # The repository to update.
+      token: "{{ requiredEnv .github.token }}" # GitHub token for authentication, marked as required.
+      username: "{{ .github.username }}" # GitHub username for authentication.
+      branch: "{{ .github.branch }}" # The branch to update with the new plugin version.
+
+# Define the sources from which to retrieve the latest Maven install plugin version.
+sources:
+  mavenInstallLatestVersion:
+    kind: maven
+    spec:
+      url: "repo1.maven.org" # The URL of the Maven repository.
+      repository: "maven2" # The specific Maven repository to use.
+      groupid: "org.apache.maven.plugins" # The group ID of the Maven install plugin.
+      artifactid: "maven-install-plugin" # The artifact ID of the Maven install plugin.
+      versionfilter:
+        kind: regex
+        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$" # Only match versions without "beta".
+
+# Define the targets where the Maven install plugin version will be applied.
+targets:
+  updateDockerfile:
+    name: "Update the value of the maven install plugin in the Dockerfile" # Description of the target.
+    kind: dockerfile
+    spec:
+      files: # The Dockerfiles to update.
+          - Dockerfile
+      instruction:
+        keyword: "ENV" # The Dockerfile instruction to target.
+        matcher: "MVN_INSTALL_PLUGIN_VERSION" # The specific ENV variable to update with the new plugin version.
+    sourceid: mavenInstallLatestVersion # Link to the source of the Maven install plugin version.
+    scmid: default # Use the default SCM configuration.
+
+# Define the actions to take after the targets are updated.
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default # Use the default SCM configuration.
+    title: 'Bump the maven install plugin version version to {{ source "mavenInstallLatestVersion" }}' # Title of the pull request.
+    spec:
+      labels:
+        - dependencies # Labels to add to the GitHub pull request.
+        - dockerfile # Additional label for the pull request.

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -1,0 +1,60 @@
+---
+name: Bump the Maven docker images versions for various tutorials
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  mavenLatestVersion:
+    kind: githubrelease
+    spec:
+      owner: "apache"
+      repository: "maven"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "~3"
+    transformers:
+      - trimprefix: "maven-"
+
+conditions:
+  testMavenAlpineImagePublished:
+    name: "Test maven:<latest_version>-eclipse-temurin-21 docker image tag"
+    kind: dockerimage
+    disablesourceinput: true
+    spec:
+      image: "maven"
+      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21'
+
+targets:
+  updateDockerfile:
+    name: "Update the value of the maven docker image in the Dockerfile"
+    kind: dockerfile
+    sourceid: mavenLatestVersion
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "FROM"
+        matcher: "maven"
+    transformers:
+      - addsuffix: "-eclipse-temurin-21"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Bump Maven Eclipse Temurin docker image version to {{ source "mavenLatestVersion" }}-eclipse-temurin-21'
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -1,60 +1,71 @@
 ---
+# This YAML configuration file is used by the updatecli tool to automate the process of updating the Maven docker image versions
+# in a Dockerfile. It defines the sources from which to retrieve the latest Maven version, the targets where this version should be applied,
+# and the actions to take upon successful updates.
+
+# Define the name of the updatecli configuration.
 name: Bump the Maven docker images versions in the Dockerfile
 
+# Define the source control management (SCM) configuration for GitHub.
 scms:
   default:
     kind: github
     spec:
-      user: "{{ .github.user }}"
-      email: "{{ .github.email }}"
-      owner: "{{ .github.owner }}"
-      repository: "{{ .github.repository }}"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      branch: "{{ .github.branch }}"
+      user: "{{ .github.user }}" # The GitHub username to use for commits.
+      email: "{{ .github.email }}" # The email associated with the GitHub user.
+      owner: "{{ .github.owner }}" # The owner of the repository where changes will be made.
+      repository: "{{ .github.repository }}" # The repository to update.
+      token: "{{ requiredEnv .github.token }}" # GitHub token for authentication, marked as required.
+      username: "{{ .github.username }}" # GitHub username for authentication.
+      branch: "{{ .github.branch }}" # The branch to update with the new Maven version.
 
+# Define the sources from which to retrieve the latest Maven version.
 sources:
   mavenLatestVersion:
     kind: githubrelease
     spec:
-      owner: "apache"
-      repository: "maven"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
+      owner: "apache" # The owner of the Maven repository on GitHub.
+      repository: "maven" # The repository name for Maven.
+      token: "{{ requiredEnv .github.token }}" # GitHub token for authentication, marked as required.
+      username: "{{ .github.username }}" # GitHub username for authentication.
       versioning:
-        kind: semver
-        pattern: "~3"
+        kind: semver # Use semantic versioning to find the latest version.
+        pattern: "~3" # Match versions that are compatible with version 3.x.
     transformers:
-      - trimprefix: "maven-"
+      - trimprefix: "maven-" # Remove the "maven-" prefix from the version string.
 
+# Define the conditions to check if the Maven Alpine image with the latest version is published.
 conditions:
   testMavenAlpineImagePublished:
-    name: "Test maven:<latest_version>-eclipse-temurin-21 docker image tag"
+    name: "Test maven:<latest_version>-eclipse-temurin-21 docker image tag" # Description of the condition.
     kind: dockerimage
     disablesourceinput: true
     spec:
-      image: "maven"
-      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21'
+      image: "maven" # The Docker image name.
+      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21' # The Docker image tag to check.
 
+# Define the targets where the Maven version will be applied.
 targets:
   updateDockerfile:
-    name: "Update the value of the maven docker image in the Dockerfile"
+    name: "Update the value of the maven docker image in the Dockerfile" # Description of the target.
     kind: dockerfile
-    sourceid: mavenLatestVersion
+    sourceid: mavenLatestVersion # Link to the source of the Maven version.
     spec:
-      file: Dockerfile
+      file: Dockerfile # The Dockerfile to update.
       instruction:
-        keyword: "FROM"
-        matcher: "maven"
+        keyword: "FROM" # The Dockerfile instruction to target.
+        matcher: "maven" # The specific Docker image to update with the new Maven version.
     transformers:
-      - addsuffix: "-eclipse-temurin-21"
-    scmid: default
+      - addsuffix: "-eclipse-temurin-21" # Add the suffix to the Maven version.
+    scmid: default # Use the default SCM configuration.
 
+# Define the actions to take after the targets are updated.
 actions:
   default:
     kind: github/pullrequest
-    scmid: default
-    title: 'Bump Maven Eclipse Temurin docker image version to {{ source "mavenLatestVersion" }}-eclipse-temurin-21'
+    scmid: default # Use the default SCM configuration.
+    title: 'Bump Maven Eclipse Temurin docker image version to {{ source "mavenLatestVersion" }}-eclipse-temurin-21' # Title of the pull request.
     spec:
       labels:
-        - dependencies
+        - dependencies # Labels to add to the GitHub pull request.
+        - Dockerfile

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump the Maven docker images versions for various tutorials
+name: Bump the Maven docker images versions in the Dockerfile
 
 scms:
   default:


### PR DESCRIPTION
# Update `FROM` image and Maven Install Plugin

The main Dockerfile was already updated with the new JDK versions. However, we were still missing updates for:

1. The main `FROM` image
2. The Maven install plugin

To address this, I've added two new `updatecli` manifests.

**Note**: The `updatecli` action will fail initially, as the `MVN_INSTALL_PLUGIN_VERSION` environment variable does not yet exist in the Dockerfile on the main branch.

## Testing Performed

I ran the following command to verify the changes:
`updatecli diff --debug --config ./updatecli/updatecli.d/maven-install.yaml --values ./updatecli/values.github-action.yaml 2>&1`

## Submitter Checklist

- [X] Opened from a **topic/feature/bugfix branch** (right side), not the main branch
- [X] Ensured the pull request title represents the desired changelog entry
- [X] Described the changes made
- [X] Provided tests demonstrating the feature works or the issue is fixed
