### PR TITLE
feat(docker): Add a `aarch64` target

### DIFF
--- a/.github/workflows/github-docker-registry-push.yml
+++ b/.github/workflows/github-docker-registry-push.yml
@@ -57,13 +57,16 @@ jobs:
 
       # Build the project with Maven and install dependencies in the Docker context
       - name: Build with Maven and install dependencies in the Docker context
-        run: mvn clean install && cp -vraxu ~/.m2 .m2 &&  lsb_release -a
+        run: mvn clean install && cp -vraxu ~/.m2 .m2
         env:
           MAVEN_CACHE: ${{ env.MAVEN_CACHE_PATH }}
 
       # Set up QEMU for multi-platform builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
+      - name: Checks which architecture is being used
+        run: lsb_release -a
 
       # Set up Docker Buildx for building multi-platform images
       - name: Set up Docker Buildx

--- a/.github/workflows/github-docker-registry-push.yml
+++ b/.github/workflows/github-docker-registry-push.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Build the project with Maven and install dependencies in the Docker context
       - name: Build with Maven and install dependencies in the Docker context
-        run: mvn clean install && cp -vraxu ~/.m2 .m2
+        run: mvn clean install && cp -vraxu ~/.m2 .m2 &&  lsb_release -a
         env:
           MAVEN_CACHE: ${{ env.MAVEN_CACHE_PATH }}
 

--- a/.github/workflows/github-docker-registry-push.yml
+++ b/.github/workflows/github-docker-registry-push.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Checks which architecture is being used
-        run: lsb_release -a
-
       # Set up Docker Buildx for building multi-platform images
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/github-docker-registry-push.yml
+++ b/.github/workflows/github-docker-registry-push.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG VERSION=999999-SNAPSHOT
 
 # First stage: Build the project using Maven and Eclipse Temurin JDK 21
-FROM maven:3.9.9-eclipse-temurin-2-jammy AS builder
+FROM maven:3.9.9-eclipse-temurin-21-jammy AS builder
 
 # Re-define the VERSION argument for the builder stage
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG VERSION=999999-SNAPSHOT
 
 # First stage: Build the project using Maven and Eclipse Temurin JDK 21
-FROM maven:3.9.9-eclipse-temurin-21 AS builder
+FROM maven:3.9.9-eclipse-temurin-2-jammy AS builder
 
 # Re-define the VERSION argument for the builder stage
 ARG VERSION
@@ -33,7 +33,7 @@ RUN cd /plugin-modernizer && \
     mvn clean install -DskipTests
 
 # Second stage: Create the final image using Maven and Eclipse Temurin JDK 21
-FROM maven:3.9.9-eclipse-temurin-21 AS result-image
+FROM maven:3.9.9-eclipse-temurin-21-jammy AS result-image
 
 LABEL org.opencontainers.image.description="Using OpenRewrite Recipes for Plugin Modernization or Automation Plugin Build Metadata Updates"
 


### PR DESCRIPTION
In the previous attempt (#269) to supply a Docker image for the tool, I had not targeted `aarch64`. 
I was able to build for both `amd64` and `aarch64` on my machine, but it wouldn't work with GitHub Actions.
Additionally, it was not functioning on a real `aarch64` machine running Ubuntu 24.04.
This may or may not be related to the now [famous `aarch64`/Ubuntu 24.04 bug](https://bugs.launchpad.net/ubuntu/+source/curl/+bug/2073448?comments=all).

I am now proposing to use Ubuntu Jammy, which has been proven to build correctly for both CPU architectures on GitHub Actions.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~