### PR TITLE
fix(updatecli): Switch to Ubuntu Jammy.

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -56,7 +56,7 @@ targets:
         keyword: "FROM" # The Dockerfile instruction to target.
         matcher: "maven" # The specific Docker image to update with the new Maven version.
     transformers:
-      - addsuffix: "-eclipse-temurin-21" # Add the suffix to the Maven version.
+      - addsuffix: "-eclipse-temurin-21-jammy" # Add the suffix to the Maven version.
     scmid: default # Use the default SCM configuration.
 
 # Define the actions to take after the targets are updated.


### PR DESCRIPTION
Yesterday, we switched to Ubuntu Jammy while adding the `aarch64` target in the #274 PR.
Unfortunately, I had not yet modified the `updatecli` manifest, which led to the #275 PR.
This automatic PR tried to change back `maven:3.9.9-eclipse-temurin-21-jammy` to `maven:3.9.9-eclipse-temurin-21` in the `FROM` instruction in the `Dockerfile` because the `updatecli` manifest was not up to date.


This PR aims at correcting that.

### Testing

`updatecli diff --config ./updatecli/updatecli.d/maven.yaml --values ./updatecli/values.github-action.yaml 2>&1`

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
