### PR TITLE
Add recipe to move to next parent version 5.x requiring 2.479 and Java 17

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -49,6 +49,22 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion
+displayName: Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17
+description: Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17
+tags: ['dependencies']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.UpgradeToJava17
+  - org.openrewrite.jenkins.UpgradeVersionProperty:
+      key: jenkins.version
+      minimumVersion: 2.479 # To be adapted when the next LTS is released
+  - org.openrewrite.maven.UpgradeParentVersion:
+      groupId: org.jenkins-ci.plugins
+      artifactId: plugin
+      newVersion: 5.X
+  - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
 displayName: Upgrade BOM version
 description: Upgrade the bom version to latest available. Doesn't change the artifact id


### PR DESCRIPTION
This will change when the next LTS is released

But will allow preparing and testing some plugin

Due to recent 5.x release update, most likely all dependabot PR will fail when trying to update the parent https://github.com/jenkinsci/jobcacher-plugin/pull/359#issuecomment-2392804791

This recipe will allow updating the next major parent, core version and also migrate to Java 17

### Testing done

Tested locally with `ansible` plugin

![parent_pom](https://github.com/user-attachments/assets/c42b54cc-fbbd-4ed2-ade6-65fd39e79717)

I would like to start opening such PR on plugin I maintain but I'm missing a `--draft` option to open draft PR (Will implement it)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
