### PR TITLE
Allow target organisation override

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -168,6 +168,7 @@
         <configuration>
           <environmentVariables>
             <GH_TOKEN>fake-token</GH_TOKEN>
+            <GH_TARGET_ORGANISATION>jenkinsci</GH_TARGET_ORGANISATION>
           </environmentVariables>
         </configuration>
         <executions>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -40,7 +40,7 @@ public class Settings {
 
     public static final String GITHUB_OWNER;
 
-    public static final String ORGANIZATION = "jenkinsci";
+    public static final String ORGANIZATION = getTargetOrganisation();
 
     public static final String RECIPE_DATA_YAML_PATH = "META-INF/rewrite/recipes.yml";
 
@@ -166,6 +166,14 @@ public class Settings {
             username = System.getenv("GITHUB_OWNER");
         }
         return username;
+    }
+
+    private static String getTargetOrganisation() {
+        String targetOrganisation = System.getenv("GH_TARGET_ORGANISATION");
+        if (targetOrganisation == null) {
+            targetOrganisation = "jenkinsci";
+        }
+        return targetOrganisation;
     }
 
     public static Path getDefaultSdkManJava(final String key) {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
@@ -258,6 +258,7 @@ public class GHServiceTest {
         GHMyself myself = Mockito.mock(GHMyself.class);
 
         // Mock
+        doReturn(repository).when(fork).getParent();
         doReturn("fake-repo").when(repository).getName();
         doReturn(Mockito.mock(URL.class)).when(fork).getHtmlUrl();
         doReturn(repository).when(plugin).getRemoteRepository(eq(service));
@@ -272,6 +273,28 @@ public class GHServiceTest {
         // Verify
         verify(repository, times(0)).fork();
         verify(myself, times(2)).getRepository(eq("fake-repo"));
+    }
+
+    @Test
+    public void shouldFailToGetForkWhenAlreadyForkedFromOtherSource() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository other = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHMyself myself = Mockito.mock(GHMyself.class);
+
+        // Mock
+        doReturn(other).when(fork).getParent();
+        doReturn("fake-repo").when(repository).getName();
+        doReturn(repository).when(plugin).getRemoteRepository(eq(service));
+        doReturn(myself).when(github).getMyself();
+
+        // Already forked
+        doReturn(fork).when(myself).getRepository(eq("fake-repo"));
+
+        assertThrows(PluginProcessingException.class, () -> {
+            service.fork(plugin);
+        });
     }
 
     @Test
@@ -306,6 +329,7 @@ public class GHServiceTest {
         GHOrganization org = Mockito.mock(GHOrganization.class);
 
         // Mock
+        doReturn(repository).when(fork).getParent();
         doReturn("fake-repo").when(repository).getName();
         doReturn(Mockito.mock(URL.class)).when(fork).getHtmlUrl();
         doReturn(repository).when(plugin).getRemoteRepository(eq(service));
@@ -320,6 +344,29 @@ public class GHServiceTest {
         // Verify
         verify(repository, times(0)).forkTo(eq(org));
         verify(org, times(2)).getRepository(eq("fake-repo"));
+    }
+
+    @Test
+    public void shouldFailtToGetForkWhenAlreadyForkedToOrganisationOfOtherSource() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository other = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHOrganization org = Mockito.mock(GHOrganization.class);
+
+        // Mock
+        doReturn(other).when(fork).getParent();
+        doReturn("fake-repo").when(repository).getName();
+        doReturn(repository).when(plugin).getRemoteRepository(eq(service));
+        doReturn(org).when(github).getOrganization("fake-owner");
+
+        // Already forked to org
+        doReturn(fork).when(org).getRepository(eq("fake-repo"));
+
+        // Test
+        assertThrows(PluginProcessingException.class, () -> {
+            service.fork(plugin);
+        });
     }
 
     @Test


### PR DESCRIPTION
While doing interactive test on https://github.com/jenkinsci/plugin-modernizer-tool/pull/295 I found that I cannot test opening PR on the jenkinsci organisation because we need an app installed by administrator. Until we are doing this I will test be creating some repo on my own org

This PR allow an environment var to be set to override the target organisation. Also add some checks and test to ensure the parent fork is the one expected

### Testing done

Automated tests and checking logs

![Screenshot from 2024-10-05 17-21-54](https://github.com/user-attachments/assets/817a05a4-32a7-4bc1-b5fd-dde548ea0f3b)


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
