### PR TITLE
2.479.1 is the first LTS dropping Java 11 support

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -25,7 +25,7 @@ public enum JDK {
      * See <a href="https://www.jenkins.io/doc/book/platform-information/support-policy-java/">Java Support Policy</a> for details
      */
     JAVA_8(8, true, null, "2.346.1"),
-    JAVA_11(11, true, "2.164.1", "2.463"), // No LTS drop Java 11 yet
+    JAVA_11(11, true, "2.164.1", "2.462.3"),
     JAVA_17(17, true, "2.346.1", null),
     JAVA_21(21, true, "2.426.1", null);
 

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -79,13 +79,17 @@ public class JDKTest {
         assertEquals(JDK.JAVA_17, JDK.get("2.426.1").get(1));
         assertEquals(JDK.JAVA_21, JDK.get("2.426.1").get(2));
 
-        assertEquals(3, JDK.get("2.463").size());
-        assertEquals(JDK.JAVA_11, JDK.get("2.463").get(0));
-        assertEquals(JDK.JAVA_17, JDK.get("2.463").get(1));
-        assertEquals(JDK.JAVA_21, JDK.get("2.463").get(2));
+        assertEquals(3, JDK.get("2.462.3").size());
+        assertEquals(JDK.JAVA_11, JDK.get("2.462.3").get(0));
+        assertEquals(JDK.JAVA_17, JDK.get("2.462.3").get(1));
+        assertEquals(JDK.JAVA_21, JDK.get("2.462.3").get(2));
 
-        assertEquals(2, JDK.get("2.464").size());
-        assertEquals(JDK.JAVA_17, JDK.get("2.464").get(0));
-        assertEquals(JDK.JAVA_21, JDK.get("2.464").get(1));
+        assertEquals(2, JDK.get("2.463").size());
+        assertEquals(JDK.JAVA_17, JDK.get("2.463").get(0));
+        assertEquals(JDK.JAVA_21, JDK.get("2.463").get(1));
+
+        assertEquals(2, JDK.get("2.479.1").size());
+        assertEquals(JDK.JAVA_17, JDK.get("2.479.1").get(0));
+        assertEquals(JDK.JAVA_21, JDK.get("2.479.1").get(1));
     }
 }


### PR DESCRIPTION
2.479.1 is the first LTS dropping Java 11 support

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
