### PR TITLE
Add recipe to migrate to latest LTS supporting Java 11

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -139,6 +139,21 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion
+displayName: Upgrade to latest LTS core version supporting Java 11
+description: Upgrade to latest LTS core version supporting Java 11
+tags: ['developer']
+recipeList:
+  # TODO: https://github.com/jenkins-infra/jenkins.io/blob/master/updatecli/updatecli.d/jenkins-lts.yaml#L104
+  # https://github.com/jenkins-infra/jenkins-version?
+  - org.openrewrite.jenkins.UpgradeVersionProperty:
+      key: jenkins.version
+      minimumVersion: 2.462.3
+  - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+  - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
+  - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeToJava17
 displayName: Migrate from Java 11 to Java 17
 description: Migrate from Java 11 to Java 17


### PR DESCRIPTION
Before migrating plugin to Java 17 and LTS 2.479.1 it's probably worth to create release just before doing so.

So this recipe is doing it

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
