### PR TITLE
Add (empty) function to remediate a precondition error of a plugin

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -7,6 +7,7 @@ import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.PreconditionError;
 import java.io.Serializable;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -116,7 +117,7 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serial
     }
 
     public Set<PreconditionError> getErrors() {
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
     public void setErrors(Set<PreconditionError> errors) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -10,6 +10,7 @@ import io.jenkins.tools.pluginmodernizer.core.utils.UpdateCenterUtils;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -242,6 +243,14 @@ public class Plugin {
     }
 
     /**
+     * Get the precondition errors of the plugin
+     * @return Set of precondition errors
+     */
+    public Set<PreconditionError> getPreconditionErrors() {
+        return Collections.unmodifiableSet(metadata.getErrors());
+    }
+
+    /**
      * Add precondition errors to the plugin errors
      */
     public void addPreconditionErrors(PluginMetadata metadata) {
@@ -252,11 +261,24 @@ public class Plugin {
     }
 
     /**
+     * Remove a precondition error from the metadata errors
+     * @param preconditionError Precondition error to remove
+     */
+    public void removePreconditionError(PreconditionError preconditionError) {
+        if (metadata == null) {
+            return;
+        }
+        metadata.setErrors(metadata.getErrors().stream()
+                .filter(error -> !error.equals(preconditionError))
+                .collect(Collectors.toSet()));
+    }
+
+    /**
      * Get the errors of the plugin
      * @return List of errors
      */
     public List<PluginProcessingException> getErrors() {
-        return errors;
+        return Collections.unmodifiableList(errors);
     }
 
     /**


### PR DESCRIPTION
Relate to https://github.com/jenkinsci/plugin-modernizer-tool/pull/307/files

But without using any transformation

@gounthar Perpaps you can "cherry-pick" code of the `PomModifier` using of each precondition error remediate function ?

For the moment we don't have tests for the `PluginModernizer` class but I've tested the function is called with the `vagrant` plugin for example. Right now all function return false because nothing is done. I left TODOs in the code

![remediation](https://github.com/user-attachments/assets/06d1fa04-25f5-4283-89ad-22958ba4926b)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
