### PR TITLE
feat(java): Helps with the migration of legacy plugins' pom.xml to JDK8.

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -14,6 +14,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
 import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.YamlResourceLoader;
 import org.slf4j.Logger;
@@ -50,6 +51,14 @@ public class Settings {
     public static final String ADOPTIUM_GITHUB_API_URL = "https://api.github.com/repos/adoptium";
 
     public static final ComparableVersion MAVEN_MINIMAL_VERSION = new ComparableVersion("3.9.7");
+
+    public static final String REMEDIATION_JENKINS_MINIMUM_VERSION;
+
+    public static final String REMEDIATION_PLUGIN_PARENT_VERSION;
+
+    public static final String REMEDIATION_BOM_BASE;
+
+    public static final String REMEDIATION_BOM_VERSION;
 
     public static final List<Recipe> AVAILABLE_RECIPES;
 
@@ -91,6 +100,11 @@ public class Settings {
         } catch (MalformedURLException e) {
             throw new ModernizerException("Invalid URL format", e);
         }
+
+        REMEDIATION_JENKINS_MINIMUM_VERSION = getRemediationJenkinsMinimumVersion();
+        REMEDIATION_BOM_BASE = getRemediationBomBase();
+        REMEDIATION_BOM_VERSION = getRemediationBomVersion();
+        REMEDIATION_PLUGIN_PARENT_VERSION = getRemediationPluginParentVersion();
 
         // Get recipes module
         try (InputStream inputStream = Settings.class.getResourceAsStream("/" + Settings.RECIPE_DATA_YAML_PATH)) {
@@ -144,6 +158,22 @@ public class Settings {
             return new URL(url);
         }
         return new URL(readProperty("plugin.versions.url", "urls.properties"));
+    }
+
+    private static @NotNull String getRemediationJenkinsMinimumVersion() {
+        return readProperty("remediation.jenkins.minimum.version", "versions.properties");
+    }
+
+    private static @NotNull String getRemediationPluginParentVersion() {
+        return readProperty("remediation.jenkins.plugin.parent.version", "versions.properties");
+    }
+
+    private static @NotNull String getRemediationBomBase() {
+        return readProperty("remediation.bom.base", "versions.properties");
+    }
+
+    private static @NotNull String getRemediationBomVersion() {
+        return readProperty("remediation.bom.version", "versions.properties");
     }
 
     private static @Nullable URL getHealthScoreUrl() throws MalformedURLException {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -133,6 +133,7 @@ public class PluginModernizer {
                 }
             }
 
+            mavenInvoker.ensureMinimalBuild(plugin);
             plugin.checkoutBranch(ghService);
 
             // Minimum JDK to run openrewrite

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -69,9 +69,6 @@ public enum PreconditionError {
                 }
             },
             plugin -> {
-                // TODO: Implement remediation function (See
-                // https://github.com/jenkinsci/plugin-modernizer-tool/pull/307)
-
                 PomModifier pomModifier = new PomModifier(
                         plugin.getLocalRepository().resolve("pom.xml").toString());
                 pomModifier.removeOffendingProperties();

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -86,7 +86,7 @@ public enum PreconditionError {
                 pomModifier.savePom(
                         plugin.getLocalRepository().resolve("pom.xml").toString());
                 plugin.withoutErrors();
-                return false;
+                return true;
             },
             "Found older Java version in pom file preventing using recent Maven older than 3.9.x"),
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -20,9 +20,7 @@ public enum PreconditionError {
      * No pom file found
      */
     NO_POM(
-            (document, xpath) -> {
-                return document == null;
-            },
+            (document, xpath) -> document == null,
             plugin -> false, // No remediation function available if pom is missing
             "No pom file found"),
 
@@ -85,6 +83,7 @@ public enum PreconditionError {
 
                 pomModifier.savePom(
                         plugin.getLocalRepository().resolve("pom.xml").toString());
+                // new CacheManager(config.getCachePath())
                 plugin.withoutErrors();
                 return true;
             },

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -168,6 +168,56 @@ public class PomModifier {
     }
 
     /**
+     * Adds a BOM section to the POM file.
+     *
+     * @param groupId the groupId of the BOM
+     * @param artifactId the artifactId of the BOM
+     * @param version the version of the BOM
+     */
+    public void addBom(String groupId, String artifactId, String version) {
+        NodeList dependencyManagementList = document.getElementsByTagName("dependencyManagement");
+        Element dependencyManagementElement;
+
+        if (dependencyManagementList.getLength() > 0) {
+            dependencyManagementElement = (Element) dependencyManagementList.item(0);
+        } else {
+            dependencyManagementElement = document.createElement("dependencyManagement");
+            document.getDocumentElement().appendChild(dependencyManagementElement);
+        }
+
+        Element dependenciesElement = (Element)
+                dependencyManagementElement.getElementsByTagName("dependencies").item(0);
+        if (dependenciesElement == null) {
+            dependenciesElement = document.createElement("dependencies");
+            dependencyManagementElement.appendChild(dependenciesElement);
+        }
+
+        Element dependencyElement = document.createElement("dependency");
+
+        Element groupIdElement = document.createElement("groupId");
+        groupIdElement.appendChild(document.createTextNode(groupId));
+        dependencyElement.appendChild(groupIdElement);
+
+        Element artifactIdElement = document.createElement("artifactId");
+        artifactIdElement.appendChild(document.createTextNode(artifactId));
+        dependencyElement.appendChild(artifactIdElement);
+
+        Element versionElement = document.createElement("version");
+        versionElement.appendChild(document.createTextNode(version));
+        dependencyElement.appendChild(versionElement);
+
+        Element typeElement = document.createElement("type");
+        typeElement.appendChild(document.createTextNode("pom"));
+        dependencyElement.appendChild(typeElement);
+
+        Element scopeElement = document.createElement("scope");
+        scopeElement.appendChild(document.createTextNode("import"));
+        dependencyElement.appendChild(scopeElement);
+
+        dependenciesElement.appendChild(dependencyElement);
+    }
+
+    /**
      * Saves the modified POM file to the specified output path.
      *
      * @param outputPath the path to save the POM file

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -1,0 +1,197 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Utility class for modifying POM files.
+ */
+public class PomModifier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PomModifier.class);
+    private Document document;
+
+    // Base directory for file operations
+    private static final String BASE_DIR = System.getProperty("java.io.tmpdir");
+
+    /**
+     * Constructor for PomModifier.
+     *
+     * @param pomFilePath the path to the POM file
+     * @throws IllegalArgumentException if the file path is invalid
+     */
+    @SuppressFBWarnings("PATH_TRAVERSAL_IN")
+    public PomModifier(String pomFilePath) {
+        try {
+            // Validate the file path
+            Path path = Paths.get(pomFilePath).normalize().toAbsolutePath();
+            if (!Files.exists(path) || !Files.isRegularFile(path)) {
+                throw new IllegalArgumentException("Invalid file path: " + path.toString());
+            }
+
+            File pomFile = path.toFile();
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbFactory.setXIncludeAware(false);
+            dbFactory.setExpandEntityReferences(false);
+            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            document = dBuilder.parse(pomFile);
+            document.getDocumentElement().normalize();
+        } catch (InvalidPathException e) {
+            LOG.error("Invalid file path: " + e.getMessage());
+            throw new IllegalArgumentException("Invalid file path: " + pomFilePath, e);
+        } catch (IllegalArgumentException e) {
+            LOG.error("Invalid file path: " + e.getMessage());
+            throw e; // Re-throw to ensure the caller is aware of the issue
+        } catch (Exception e) {
+            LOG.error("Error initializing PomModifier: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to initialize PomModifier", e); // Re-throw as a runtime exception
+        }
+    }
+
+    /**
+     * Removes offending properties from the POM file.
+     */
+    public void removeOffendingProperties() {
+        NodeList propertiesList = document.getElementsByTagName("properties");
+        if (propertiesList.getLength() > 0) {
+            Node propertiesNode = propertiesList.item(0);
+            NodeList childNodes = propertiesNode.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node node = childNodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE) {
+                    String nodeName = node.getNodeName();
+                    if (nodeName.equals("jenkins-test-harness.version") || nodeName.equals("java.level")) {
+                        propertiesNode.removeChild(node);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Updates the parent POM information.
+     *
+     * @param groupId the groupId to set
+     * @param artifactId the artifactId to set
+     * @param version the version to set
+     */
+    public void updateParentPom(String groupId, String artifactId, String version) {
+        NodeList parentList = document.getElementsByTagName("parent");
+        if (parentList.getLength() > 0) {
+            Node parentNode = parentList.item(0);
+            NodeList childNodes = parentNode.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node node = childNodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE) {
+                    switch (node.getNodeName()) {
+                        case "groupId":
+                            node.setTextContent(groupId);
+                            break;
+                        case "artifactId":
+                            node.setTextContent(artifactId);
+                            break;
+                        case "version":
+                            node.setTextContent(version);
+                            break;
+                        default:
+                            LOG.warn("Unexpected element in parent POM: " + node.getNodeName());
+                            break;
+                    }
+                }
+            }
+        } else {
+            Element parentElement = document.createElement("parent");
+
+            Element groupIdElement = document.createElement("groupId");
+            groupIdElement.appendChild(document.createTextNode(groupId));
+            parentElement.appendChild(groupIdElement);
+
+            Element artifactIdElement = document.createElement("artifactId");
+            artifactIdElement.appendChild(document.createTextNode(artifactId));
+            parentElement.appendChild(artifactIdElement);
+
+            Element versionElement = document.createElement("version");
+            versionElement.appendChild(document.createTextNode(version));
+            parentElement.appendChild(versionElement);
+
+            document.getDocumentElement().appendChild(parentElement);
+        }
+    }
+
+    /**
+     * Updates the Jenkins minimal version in the POM file.
+     *
+     * @param version the version to set
+     */
+    public void updateJenkinsMinimalVersion(String version) {
+        NodeList propertiesList = document.getElementsByTagName("properties");
+        if (propertiesList.getLength() > 0) {
+            Node propertiesNode = propertiesList.item(0);
+            NodeList childNodes = propertiesNode.getChildNodes();
+            boolean versionUpdated = false;
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node node = childNodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE
+                        && node.getNodeName().equals("jenkins.version")) {
+                    node.setTextContent(version);
+                    versionUpdated = true;
+                    break;
+                }
+            }
+            if (!versionUpdated) {
+                Element jenkinsVersionElement = document.createElement("jenkins.version");
+                jenkinsVersionElement.appendChild(document.createTextNode(version));
+                propertiesNode.appendChild(jenkinsVersionElement);
+            }
+        }
+    }
+
+    /**
+     * Saves the modified POM file to the specified output path.
+     *
+     * @param outputPath the path to save the POM file
+     * @throws IllegalArgumentException if the output path is invalid
+     */
+    @SuppressFBWarnings("PATH_TRAVERSAL_IN")
+    public void savePom(String outputPath) {
+        try {
+            // Validate the output path
+            Path path = Paths.get(outputPath).normalize().toAbsolutePath();
+
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            DOMSource source = new DOMSource(document);
+            StreamResult result = new StreamResult(new File(outputPath));
+            transformer.transform(source, result);
+        } catch (InvalidPathException e) {
+            LOG.error("Invalid output path: " + e.getMessage());
+            throw new IllegalArgumentException("Invalid output path: " + outputPath, e);
+        } catch (Exception e) {
+            LOG.error("Error saving POM file: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to save POM file", e);
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -1,5 +1,5 @@
 openrewrite.maven.plugin.version = ${openrewrite.maven.plugin.version}
-jenkins.minimum.version = 2.440.3
-jenkins.plugin.parent.version = 4.80
-bom.version = 3413.v0d896b_76a_30d
-bom.base = bom-2.440.x
+remediation.jenkins.minimum.version = 2.440.3
+remediation.jenkins.plugin.parent.version = 4.51
+remediation.bom.version = 3413.v0d896b_76a_30d
+remediation.bom.base = bom-2.440.x

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -1,0 +1,110 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import static java.nio.file.Files.createTempFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.logging.Logger;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class PomModifierTest {
+    private static final Logger logger = Logger.getLogger(PomModifierTest.class.getName());
+
+    private static final String TEST_POM_PATH = "src/test/resources/test-pom.xml";
+    private static final String OUTPUT_POM_PATH;
+
+    static {
+        try {
+            OUTPUT_POM_PATH = Files.move(
+                            createTempFile(null, null),
+                            Paths.get(System.getProperty("java.io.tmpdir"), "output-pom.xml"),
+                            StandardCopyOption.REPLACE_EXISTING)
+                    .toAbsolutePath()
+                    .toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Path tempFile = new File(OUTPUT_POM_PATH).toPath();
+        Files.copy(Path.of(TEST_POM_PATH), tempFile, StandardCopyOption.REPLACE_EXISTING);
+        logger.info("Setup completed, copied test POM to temporary file: " + tempFile.toString());
+    }
+
+    @Test
+    public void testRemoveOffendingProperties() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.removeOffendingProperties();
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        Element propertiesElement =
+                (Element) doc.getElementsByTagName("properties").item(0);
+        assertTrue(propertiesElement.getElementsByTagName("java.level").getLength() == 0);
+        assertTrue(propertiesElement
+                        .getElementsByTagName("jenkins-test-harness.version")
+                        .getLength()
+                == 0);
+        logger.info("Offending properties removed successfully");
+    }
+
+    @Test
+    public void testUpdateParentPom() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.updateParentPom("org.jenkins-ci.plugins", "plugin", "4.80");
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        Element parentElement = (Element) doc.getElementsByTagName("parent").item(0);
+        assertEquals(
+                "org.jenkins-ci.plugins",
+                parentElement.getElementsByTagName("groupId").item(0).getTextContent());
+        assertEquals(
+                "plugin",
+                parentElement.getElementsByTagName("artifactId").item(0).getTextContent());
+        assertEquals(
+                "4.80", parentElement.getElementsByTagName("version").item(0).getTextContent());
+    }
+
+    @Test
+    public void testUpdateJenkinsMinimalVersion() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.updateJenkinsMinimalVersion("2.462.2");
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        Element propertiesElement =
+                (Element) doc.getElementsByTagName("properties").item(0);
+        String jenkinsVersion = propertiesElement
+                .getElementsByTagName("jenkins.version")
+                .item(0)
+                .getTextContent();
+        logger.info("Jenkins version found: " + jenkinsVersion);
+        assertEquals("2.462.2", jenkinsVersion);
+    }
+}

--- a/plugin-modernizer-core/src/test/resources/test-pom.xml
+++ b/plugin-modernizer-core/src/test/resources/test-pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>1.554.1</version>
+    <relativePath />
+  </parent>
+
+  <properties>
+    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+    <jenkins.version>1.532.3</jenkins.version>
+    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
+    <java.level>7</java.level>
+    <!-- Jenkins Test Harness version you use to test the plugin. -->
+    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
+    <jenkins-test-harness.version>1.532.3</jenkins-test-harness.version>
+    <!-- Other properties you may want to use:
+         ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
+         ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
+    -->
+  </properties>
+  <groupId>org.jenkins-ci.plugins</groupId>
+  <artifactId>vagrant</artifactId>
+  <version>1.0.3-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>vagrant</name>
+  <description>Vagrant plugin to execute and manage vagrant commands on remote nodes</description>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Vagrant-plugin</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>ShimiTaNaka</id>
+      <name>Elad Shmitanka</name>
+      <email>elad.shmitanka@gmail.com</email>
+    </developer>
+  </developers>
+
+  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <scm>
+    <connection>scm:git:ssh://github.com/jenkinsci/vagrant-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/vagrant-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/vagrant-plugin</url>
+    <tag>vagrant-1.0.3</tag>
+  </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <compatibleSinceVersion>1.0.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Supersedes #307, solves #215.

## Purpose of this PR
This pull request is a work in progress based on #307. It compiles and passes the automatic tests but fails to upgrade the `vagrant` plugin.

## Goal of the Code Modification
The proposed code will forcefully modify the `pom.xml` file when we detect a JDK version older than 8.

## Modifications Made
When conditions are met, the code:
1. Changes the POM parent
2. Updates the Jenkins version
3. Removes the `jdk.version` property
4. Adds the BOM (Bill of Materials)

## Limitations
This approach is not a universal solution and may not work for every plugin. However, it successfully upgraded the [outdated Vagrant plugin](#215) and could serve as a foundation for future improvements.

## Testing Performed
The modification was tested using the following command:
`java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins vagrant --recipes MinimalBuildJava8 --ignore-jdk7-error --debug --dry-run`

## Status
This PR will remain in draft status until we resolve the following issue:
```
Moved plugin vagrant metadata to cache: /home/poddingue/.cache/jenkins-plugin-modernizer-cli/vagrant/plugin-metadata
Unexpected processing error. Check the logs at logs/vagrant.log
java.lang.NullPointerException: Cannot invoke "java.util.Set.getClass()" because "s" is null
        at java.base/java.util.Collections.unmodifiableSet(Collections.java:1237)
        at io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata.getErrors(PluginMetadata.java:120)
        at io.jenkins.tools.pluginmodernizer.core.model.Plugin.hasPreconditionErrors(Plugin.java:241)
        at io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer.process(PluginModernizer.java:173)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        at io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer.start(PluginModernizer.java:75)
        at io.jenkins.tools.pluginmodernizer.cli.Main.run(Main.java:252)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2030)
        at picocli.CommandLine.executeHelpRequest(CommandLine.java:2016)
        at picocli.CommandLine.executeHelpRequest(CommandLine.java:1987)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2272)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at io.jenkins.tools.pluginmodernizer.cli.Main.main(Main.java:47)
*************
```

In my previous attempts (#307), I encountered a similar issue that disappeared after retrying the metadata fetching before allowing the standard process to proceed:

```java
// Retry the metadata fetching
plugin.collectMetadata(mavenInvoker);
plugin.moveMetadata(cacheManager);
```

I'm currently unsure how to implement this solution with the current version of the code.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
