### PR TITLE
fix(jdk7): Remove comments associated with deleted properties in pom.xml

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -82,6 +82,12 @@ public class PomModifier {
                 if (node.getNodeType() == Node.ELEMENT_NODE) {
                     String nodeName = node.getNodeName();
                     if (nodeName.equals("jenkins-test-harness.version") || nodeName.equals("java.level")) {
+                        // Remove associated comments
+                        Node previousSibling = node.getPreviousSibling();
+                        while (previousSibling != null && previousSibling.getNodeType() == Node.COMMENT_NODE) {
+                            propertiesNode.removeChild(previousSibling);
+                            previousSibling = node.getPreviousSibling();
+                        }
                         propertiesNode.removeChild(node);
                     }
                 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -1,7 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.core.utils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -16,7 +15,6 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -92,7 +90,16 @@ public class PomModifier {
                         int j = i - 1;
                         while (j >= 0) {
                             Node previousNode = childNodes.item(j);
-                            if (previousNode.getNodeType() == Node.COMMENT_NODE || (previousNode.getNodeType() == Node.TEXT_NODE && previousNode.getTextContent().trim().startsWith("<!--")) || previousNode.getTextContent().replaceAll("\\s+", "").isEmpty()) {
+                            if (previousNode.getNodeType() == Node.COMMENT_NODE
+                                    || (previousNode.getNodeType() == Node.TEXT_NODE
+                                            && previousNode
+                                                    .getTextContent()
+                                                    .trim()
+                                                    .startsWith("<!--"))
+                                    || previousNode
+                                            .getTextContent()
+                                            .replaceAll("\\s+", "")
+                                            .isEmpty()) {
                                 nodesToRemove.add(previousNode);
                                 j--;
                             } else {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -63,6 +63,11 @@ public class PomModifierTest {
                         .getLength()
                 == 0);
         logger.info("Offending properties removed successfully");
+
+        // Verify that comments associated with the removed properties are also removed
+        String pomContent = new String(Files.readAllBytes(Paths.get(OUTPUT_POM_PATH)));
+        assertTrue(!pomContent.contains("<!-- Java Level to use. Java 7 required when using core >= 1.612 -->"));
+        assertTrue(!pomContent.contains("<!-- Jenkins Test Harness version you use to test the plugin. -->"));
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * Test class for PomModifier.
+ */
 public class PomModifierTest {
     private static final Logger logger = Logger.getLogger(PomModifierTest.class.getName());
 
@@ -36,6 +39,11 @@ public class PomModifierTest {
         }
     }
 
+    /**
+     * Sets up the test environment by copying the test POM file to a temporary file.
+     *
+     * @throws Exception if an error occurs during setup
+     */
     @BeforeEach
     public void setUp() throws Exception {
         Path tempFile = new File(OUTPUT_POM_PATH).toPath();
@@ -43,6 +51,11 @@ public class PomModifierTest {
         logger.info("Setup completed, copied test POM to temporary file: " + tempFile);
     }
 
+    /**
+     * Tests the removeOffendingProperties method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
     @Test
     public void testRemoveOffendingProperties() throws Exception {
         PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
@@ -77,6 +90,11 @@ public class PomModifierTest {
                 "Comment for jenkins-test-harness.version should be removed");
     }
 
+    /**
+     * Tests the updateParentPom method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
     @Test
     public void testUpdateParentPom() throws Exception {
         PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
@@ -99,6 +117,11 @@ public class PomModifierTest {
                 "4.80", parentElement.getElementsByTagName("version").item(0).getTextContent());
     }
 
+    /**
+     * Tests the updateJenkinsMinimalVersion method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
     @Test
     public void testUpdateJenkinsMinimalVersion() throws Exception {
         PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -1,8 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.core.utils;
 
 import static java.nio.file.Files.createTempFile;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +40,7 @@ public class PomModifierTest {
     public void setUp() throws Exception {
         Path tempFile = new File(OUTPUT_POM_PATH).toPath();
         Files.copy(Path.of(TEST_POM_PATH), tempFile, StandardCopyOption.REPLACE_EXISTING);
-        logger.info("Setup completed, copied test POM to temporary file: " + tempFile.toString());
+        logger.info("Setup completed, copied test POM to temporary file: " + tempFile);
     }
 
     @Test
@@ -57,17 +56,25 @@ public class PomModifierTest {
 
         Element propertiesElement =
                 (Element) doc.getElementsByTagName("properties").item(0);
-        assertTrue(propertiesElement.getElementsByTagName("java.level").getLength() == 0);
-        assertTrue(propertiesElement
+        assertEquals(
+                0,
+                propertiesElement.getElementsByTagName("java.level").getLength(),
+                "java.level property should be removed");
+        assertEquals(
+                0,
+                propertiesElement
                         .getElementsByTagName("jenkins-test-harness.version")
-                        .getLength()
-                == 0);
-        logger.info("Offending properties removed successfully");
+                        .getLength(),
+                "jenkins-test-harness.version property should be removed");
 
         // Verify that comments associated with the removed properties are also removed
         String pomContent = new String(Files.readAllBytes(Paths.get(OUTPUT_POM_PATH)));
-        assertTrue(!pomContent.contains("<!-- Java Level to use. Java 7 required when using core >= 1.612 -->"));
-        assertTrue(!pomContent.contains("<!-- Jenkins Test Harness version you use to test the plugin. -->"));
+        assertFalse(
+                pomContent.contains("Java Level to use. Java 7 required when using core >= 1.612"),
+                "Comment for java.level should be removed");
+        assertFalse(
+                pomContent.contains("Jenkins Test Harness version you use to test the plugin."),
+                "Comment for jenkins-test-harness.version should be removed");
     }
 
     @Test


### PR DESCRIPTION
Enhance the `removeOffendingProperties` method in `PomModifier.java` to remove comments associated with deleted properties.

* Identify comments directly above the properties `jenkins-test-harness.version` and `java.level` and remove them along with the properties.
* Update unit tests in `PomModifierTest.java` to verify the removal of comments associated with deleted properties.

### Testing done

`mvn install`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
