### PR TITLE
New datasource for metadata related to plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ To activate app authentication, just set the following CLI argument
 
 - `--debug` or `-d`: (optional) Enables debug mode.
 
-- `--jenkins-update-center`: (optional) Sets main update center; will override JENKINS_UC environment variable. If not set via CLI option or environment variable, will default to url in [properties file](plugin-modernizer-core/src/main/resources/update_center.properties)
+- `--jenkins-update-center`: (optional) Sets main update center; will override JENKINS_UC environment variable. If not set via CLI option or environment variable, will default to url in [properties file](plugin-modernizer-core/src/main/resources/urls.properties)
+
+- `--jenkins-plugins-stats-installations-url` (optional) Set the URL for the Jenkins Plugins Stats installations API. If not set via CLI option or environment variable, will default to url in [properties file](plugin-modernizer-core/src/main/resources/urls.properties)
 
 - `--cache-path` or `-c`: (optional) Custom path to the cache directory. Defaults to `${user.home}/.cache/jenkins-plugin-modernizer-cli`.
 

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -158,6 +158,12 @@ public class Main implements Runnable {
     public URL pluginHealthScore = Settings.DEFAULT_HEALTH_SCORE_URL;
 
     @Option(
+            names = "--jenkins-plugins-stats-installations-url",
+            description =
+                    "Sets the Jenkins stats top plugins URL; will override JENKINS_PLUGINS_STATS_INSTALLATIONS_URL environment variable. If not set via CLI option or environment variable, will use default Jenkins stats top plugins url.")
+    public URL jenkinsPluginsStatsInstallationsUrl = Settings.DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
+
+    @Option(
             names = {"-c", "--cache-path"},
             description = "Path to the cache directory.")
     public Path cachePath = Settings.DEFAULT_CACHE_PATH;
@@ -193,6 +199,7 @@ public class Main implements Runnable {
                 .withJenkinsUpdateCenter(jenkinsUpdateCenter)
                 .withJenkinsPluginVersions(jenkinsPluginVersions)
                 .withPluginHealthScore(pluginHealthScore)
+                .withPluginStatsInstallations(jenkinsPluginsStatsInstallationsUrl)
                 .withCachePath(
                         !cachePath.endsWith(Settings.CACHE_SUBDIR)
                                 ? cachePath.resolve(Settings.CACHE_SUBDIR)

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -18,6 +18,7 @@ public class Config {
     private final URL jenkinsUpdateCenter;
     private final URL jenkinsPluginVersions;
     private final URL pluginHealthScore;
+    private final URL pluginStatsInstallations;
     private final Path cachePath;
     private final Path mavenHome;
     private final boolean dryRun;
@@ -43,6 +44,7 @@ public class Config {
             URL jenkinsUpdateCenter,
             URL jenkinsPluginVersions,
             URL pluginHealthScore,
+            URL pluginStatsInstallations,
             Path cachePath,
             Path mavenHome,
             boolean dryRun,
@@ -62,6 +64,7 @@ public class Config {
         this.jenkinsUpdateCenter = jenkinsUpdateCenter;
         this.jenkinsPluginVersions = jenkinsPluginVersions;
         this.pluginHealthScore = pluginHealthScore;
+        this.pluginStatsInstallations = pluginStatsInstallations;
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
         this.dryRun = dryRun;
@@ -121,6 +124,10 @@ public class Config {
         return pluginHealthScore;
     }
 
+    public URL getPluginStatsInstallations() {
+        return pluginStatsInstallations;
+    }
+
     public Path getCachePath() {
         return cachePath;
     }
@@ -175,6 +182,7 @@ public class Config {
         private List<Recipe> recipes;
         private URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
         private URL jenkinsPluginVersions = Settings.DEFAULT_PLUGIN_VERSIONS;
+        private URL pluginStatsInstallations = Settings.DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
         private URL pluginHealthScore = Settings.DEFAULT_HEALTH_SCORE_URL;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
@@ -242,6 +250,13 @@ public class Config {
             return this;
         }
 
+        public Builder withPluginStatsInstallations(URL pluginStatsInstallations) {
+            if (pluginStatsInstallations != null) {
+                this.pluginStatsInstallations = pluginStatsInstallations;
+            }
+            return this;
+        }
+
         public Builder withCachePath(Path cachePath) {
             if (cachePath != null) {
                 this.cachePath = cachePath;
@@ -303,6 +318,7 @@ public class Config {
                     jenkinsUpdateCenter,
                     jenkinsPluginVersions,
                     pluginHealthScore,
+                    pluginStatsInstallations,
                     cachePath,
                     mavenHome,
                     dryRun,

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -28,6 +28,8 @@ public class Settings {
 
     public static final URL DEFAULT_PLUGIN_VERSIONS;
 
+    public static final URL DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
+
     public static final URL DEFAULT_HEALTH_SCORE_URL;
 
     public static final Path DEFAULT_CACHE_PATH;
@@ -99,6 +101,11 @@ public class Settings {
         }
         try {
             DEFAULT_HEALTH_SCORE_URL = getHealthScoreUrl();
+        } catch (MalformedURLException e) {
+            throw new ModernizerException("Invalid URL format", e);
+        }
+        try {
+            DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL = getPluginsStatsInstallationsUrl();
         } catch (MalformedURLException e) {
             throw new ModernizerException("Invalid URL format", e);
         }
@@ -184,6 +191,14 @@ public class Settings {
             return new URL(url);
         }
         return new URL(readProperty("plugin.health.score.url", "urls.properties"));
+    }
+
+    private static @Nullable URL getPluginsStatsInstallationsUrl() throws MalformedURLException {
+        String url = System.getenv("JENKINS_PLUGINS_STATS_INSTALLATIONS_URL");
+        if (url != null) {
+            return new URL(url);
+        }
+        return new URL(readProperty("plugin.stats.installations.plugin.url", "urls.properties"));
     }
 
     private static String getGithubToken() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFlag.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFlag.java
@@ -95,7 +95,12 @@ public enum MetadataFlag {
     /**
      * If the plugin has a low score
      */
-    HAS_LOW_SCORE(null, (plugin, pluginService) -> pluginService.hasLowScore(plugin));
+    HAS_LOW_SCORE(null, (plugin, pluginService) -> pluginService.hasLowScore(plugin)),
+
+    /**
+     * If the plugin has no known installation
+     */
+    NO_KNOWN_INSTALLATION(null, (plugin, pluginService) -> pluginService.hasNoKnownInstallations(plugin));
 
     /**
      * Function to check if the flag is applicable for the given XML tag

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -20,6 +20,7 @@ public class CacheManager {
     public static final String UPDATE_CENTER_CACHE_KEY = "update-center";
     public static final String PLUGIN_VERSIONS_CACHE_KEY = "plugin-versions";
     public static final String HEALTH_SCORE_KEY = "health-score";
+    public static final String INSTALLATION_STATS_KEY = "plugin-installation-stats";
     public static final String PLUGIN_METADATA_CACHE_KEY = "plugin-metadata";
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheManager.class);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -60,6 +60,7 @@ public class PluginModernizer {
         LOG.debug("Update Center Url: {}", config.getJenkinsUpdateCenter());
         LOG.debug("Plugin versions Url: {}", config.getJenkinsPluginVersions());
         LOG.debug("Plugin Health Score Url: {}", config.getPluginHealthScore());
+        LOG.debug("Installation Stats Url: {}", config.getPluginStatsInstallations());
         LOG.debug("Cache Path: {}", config.getCachePath());
         LOG.debug("Dry Run: {}", config.isDryRun());
         LOG.debug("Skip Push: {}", config.isSkipPush());
@@ -89,6 +90,7 @@ public class PluginModernizer {
 
             LOG.debug("Plugin {} latest version: {}", plugin.getName(), pluginService.extractVersion(plugin));
             LOG.debug("Plugin {} health score: {}", plugin.getName(), pluginService.extractScore(plugin));
+            LOG.debug("Plugin {} installations: {}", plugin.getName(), pluginService.extractInstallationStats(plugin));
             LOG.debug("Is API plugin {} : {}", plugin.getName(), plugin.isApiPlugin(pluginService));
             if (plugin.isDeprecated(pluginService)) {
                 LOG.info("Plugin {} is deprecated. Skipping.", plugin.getName());

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginInstallationStatsData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginInstallationStatsData.java
@@ -1,0 +1,26 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.Map;
+
+public class PluginInstallationStatsData extends CacheEntry<PluginInstallationStatsData> implements Serializable {
+
+    /**
+     * Plugins in the installation stats mapped by their name
+     */
+    private Map<String, Integer> plugins;
+
+    public PluginInstallationStatsData(CacheManager cacheManager) {
+        super(cacheManager, PluginInstallationStatsData.class, CacheManager.INSTALLATION_STATS_KEY, Path.of("."));
+    }
+
+    public Map<String, Integer> getPlugins() {
+        return plugins;
+    }
+
+    public void setPlugins(Map<String, Integer> plugins) {
+        this.plugins = plugins;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/CSVUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/CSVUtils.java
@@ -1,0 +1,67 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import com.google.gson.JsonSyntaxException;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CSVUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CSVUtils.class);
+
+    private CSVUtils() {
+        // Hide constructor
+    }
+
+    /**
+     * Download CSV data from a URL and convert it to an object
+     * @param url The URL to download from
+     * @return The object
+     */
+    public static String fromUrl(URL url) {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            HttpRequest request =
+                    HttpRequest.newBuilder().GET().uri(url.toURI()).build();
+            LOG.debug("Fetching data from: {}", url);
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new ModernizerException(
+                        "Failed to get CSV data. Received response code: " + response.statusCode());
+            }
+            LOG.debug("Fetched data from: {}", url);
+            return response.body();
+        } catch (IOException | JsonSyntaxException | URISyntaxException | InterruptedException e) {
+            throw new ModernizerException("Unable to fetch data from " + url, e);
+        }
+    }
+
+    /**
+     * Parse a 2 column CSV stats
+     * @param data The CSV data
+     * @return The parsed stats
+     */
+    public static Map<String, Integer> parseStats(String data) {
+        Map<String, Integer> stats = new HashMap<>();
+        String[] lines = data.split("\n");
+        for (String line : lines) {
+            String[] columns = line.split(",");
+            if (columns.length == 2) {
+                String pluginName = columns[0].trim().replace("\"", "");
+                Integer installations = Integer.parseInt(columns[1].trim().replace("\"", ""));
+                stats.put(pluginName, installations);
+            }
+        }
+        return stats;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
@@ -157,6 +157,26 @@ public class PluginService {
     }
 
     /**
+     * Retrieve installation stats data from the given URL
+     */
+    public PluginInstallationStatsData downloadInstallationStatsData() {
+        String data = CSVUtils.fromUrl(config.getPluginStatsInstallations());
+        PluginInstallationStatsData pluginInstallationStatsData = new PluginInstallationStatsData(cacheManager);
+        pluginInstallationStatsData.setPlugins(CSVUtils.parseStats(data));
+        return pluginInstallationStatsData;
+    }
+
+    /**
+     * Extract the installation stats for a plugin
+     * @param plugin Plugin
+     * @return Installation stats
+     */
+    public Integer extractInstallationStats(Plugin plugin) {
+        PluginInstallationStatsData pluginInstallationStatsData = getPluginInstallationStatsData();
+        return pluginInstallationStatsData.getPlugins().get(plugin.getName());
+    }
+
+    /**
      * Extract the score for a plugin. Null if not found
      * @param plugin Plugin
      * @return Score
@@ -192,6 +212,16 @@ public class PluginService {
     }
 
     /**
+     * Check if a plugin has no known installations
+     * @param plugin Plugin
+     * @return True if no known installation
+     */
+    public boolean hasNoKnownInstallations(Plugin plugin) {
+        Integer installations = extractInstallationStats(plugin);
+        return installations == null || installations == 0;
+    }
+
+    /**
      * Retrieve plugin version data from the given URL of from cache if it exists
      * @return Plugin version data
      */
@@ -206,6 +236,23 @@ public class PluginService {
             cacheManager.put(pluginVersionData);
         }
         return pluginVersionData;
+    }
+
+    /**
+     * Retrieve plugin installation stats data from the given URL of from cache if it exists
+     * @return Plugin installation stats data
+     */
+    public PluginInstallationStatsData getPluginInstallationStatsData() {
+        PluginInstallationStatsData pluginInstallationStatsData = cacheManager.get(
+                cacheManager.root(), CacheManager.INSTALLATION_STATS_KEY, PluginInstallationStatsData.class);
+        // Download and update cache
+        if (pluginInstallationStatsData == null) {
+            pluginInstallationStatsData = downloadInstallationStatsData();
+            pluginInstallationStatsData.setKey(CacheManager.INSTALLATION_STATS_KEY);
+            pluginInstallationStatsData.setPath(cacheManager.root());
+            cacheManager.put(pluginInstallationStatsData);
+        }
+        return pluginInstallationStatsData;
     }
 
     /**

--- a/plugin-modernizer-core/src/main/resources/urls.properties
+++ b/plugin-modernizer-core/src/main/resources/urls.properties
@@ -1,3 +1,4 @@
 update.center.url=https://updates.jenkins.io/current/update-center.actual.json
 plugin.versions.url=https://updates.jenkins.io/current/plugin-versions.json
 plugin.health.score.url=https://plugin-health.jenkins.io/api/scores
+plugin.stats.installations.plugin.url=https://stats.jenkins.io/jenkins-stats/svg/202406-plugins.csv


### PR DESCRIPTION
New datasource for metadata related to plugin installation

Almost ready for review, just need some cleanup. And some automated tests missing

Tested with few plugin

```json
{"pluginName":"CTRF","flags":["MAVEN_REPOSITORIES_HTTPS","LICENSE_SET","SCM_HTTPS","NO_KNOWN_INSTALLATION"]}
```

![Screenshot from 2024-10-12 13-51-24](https://github.com/user-attachments/assets/7fb8dd8c-4b86-4c5c-b77e-33192e97ea22)



### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
