### PR TITLE
Add recipe to delete updatecli workflows

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -168,3 +168,14 @@ description: Convert JUnit 4 TestCase to JUnit Jupiter
 tags: ['tests']
 recipeList:
   - org.openrewrite.java.testing.junit5.MigrateJUnitTestCase
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.DeleteUpdateCliWorkflows
+displayName: Remove updatecli workflows
+description: Remove updatecli workflows
+tags: ['chore']
+recipeList:
+  - org.openrewrite.DeleteSourceFiles:
+      filePattern: .github/workflows/updatecli.yml
+  - org.openrewrite.DeleteSourceFiles:
+      filePattern: updatecli/**/*.yml


### PR DESCRIPTION
I might delete it at some point.

But some of my plugin were using some updatecli workflows to bump the jenkins code version.

This can now be replaced by OpenRewrite

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

