### PR TITLE
feat(recipes): Add ModernizeJenkinsfile Recipe and UpgradeNextMajorParentVersion Dependency

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -185,7 +185,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.AddOrModernizeJenkinsFile
 displayName: Add Jenkinsfile
-description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings., or creates the file is absent.
+description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings, or creates the file if absent.
 tags: ['chore']
 recipeList:
   - org.openrewrite.jenkins.ModernizeJenkinsfile

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -183,7 +183,7 @@ recipeList:
       filePattern: updatecli/**/*.yml
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.jenkins.tools.pluginmodernizer.AddJenkinsFile
+name: io.jenkins.tools.pluginmodernizer.AddOrModernizeJenkinsFile
 displayName: Add Jenkinsfile
 description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings., or creates the file is absent.
 tags: ['chore']

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -181,3 +181,12 @@ recipeList:
       filePattern: updatecli/values.yml
   - org.openrewrite.DeleteSourceFiles:
       filePattern: updatecli/**/*.yml
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.AddJenkinsFile
+displayName: Add Jenkinsfile
+description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings., or creates the file is absent.
+tags: ['chore']
+recipeList:
+  - org.openrewrite.jenkins.ModernizeJenkinsfile
+  - io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -185,7 +185,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.AddOrModernizeJenkinsFile
 displayName: Add Jenkinsfile
-description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings, or creates the file if absent.
+description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings, or creates the file if absent. Also upgrades to the next parent major version, as the new version of the Jenkinsfille uses JDK17 and JDK21.
 tags: ['chore']
 recipeList:
   - org.openrewrite.jenkins.ModernizeJenkinsfile

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -185,8 +185,8 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.AddOrModernizeJenkinsFile
 displayName: Add Jenkinsfile
-description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings, or creates the file if absent. Also upgrades to the next parent major version, as the new version of the Jenkinsfille uses JDK17 and JDK21.
+description: Updates Jenkinsfile to build with recommended Java versions, platforms, and settings, or creates the file if absent. Also upgrades to a newer parent version, as the new version of the Jenkinsfille uses JDK17 and JDK21.
 tags: ['chore']
 recipeList:
   - org.openrewrite.jenkins.ModernizeJenkinsfile
-  - io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion
+  - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion


### PR DESCRIPTION
This PR introduces two key enhancements to our recipe collection:

1. Integration of the OpenRewrite recipe `org.openrewrite.jenkins.ModernizeJenkinsfile` into a new modernizer recipe called `AddOrModernizeJenkinsFile`.
2. Addition of the `UpgradeNextMajorParentVersion` as a dependency for the new recipe.

## Rationale for Dependency

The inclusion of `UpgradeNextMajorParentVersion` as a dependency is based on `ModernizeJenkinsfile`'s latest version, which produces a Jenkinsfile that:
- Tests with JDK 17 on Windows
- Tests with JDK 21 on Linux

This dependency ensures our modernization efforts align with current testing practices across different environments.

## Testing Performed

To verify the functionality of the new recipe, the following command was executed:

`rm -fr ~/.cache/jenkins-plugin-modernizer-cli/vagrant/ && java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins vagrant --recipes MinimalBuildJava8,AddOrModernizeJenkinsFile --debug`

This test resulted in the creation of a pull request: [jenkinsci/vagrant-plugin#13](https://github.com/jenkinsci/vagrant-plugin/pull/13).

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
