### PR TITLE
feat(recipes): Add a dependabot GitHub action file

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -190,3 +190,24 @@ tags: ['chore']
 recipeList:
   - org.openrewrite.jenkins.ModernizeJenkinsfile
   - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.AddDependencyCheck
+displayName: Add dependency check
+description: Adds a dependabot GitHub action to the plugin repository
+tags: ['chore']
+recipeList:
+  - org.openrewrite.text.CreateTextFile:
+      fileContents: |
+        version: 2
+        updates:
+        - package-ecosystem: maven
+          directory: /
+          schedule:
+            interval: monthly
+        - package-ecosystem: github-actions
+          directory: /
+          schedule:
+            interval: monthly
+      relativeFileName: .github/dependabot.yml
+      overwriteExisting: false


### PR DESCRIPTION
Fixes #337.

Thanks a lot for the [tip](https://github.com/jenkinsci/plugin-modernizer-tool/issues/337#issuecomment-2419172712), @jonesbusy, I didn't know we could do as simple as that. 😉 

## Summary 

- **New Features**
	- Introduced a new recipe for managing dependencies, enabling integration of a GitHub action for dependency checking in Jenkins plugins.
	
	<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
<!-- walkthrough_start -->

## Walkthrough
The changes in this pull request introduce a new recipe for Jenkins plugin dependency management, specifically `io.jenkins.tools.pluginmodernizer.AddDependencyCheck`, which facilitates the integration of a GitHub action for dependency checking. 

## Changes

| File Path                                                                 | Change Summary                                                                                  |
|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
| `plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml` | - Added new recipe `AddDependencyCheck` for GitHub action dependency checking.<br> |

### Testing done
`rm -fr ~/.cache/jenkins-plugin-modernizer-cli/vagrant/ && java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins vagrant --recipes MinimalBuildJava8,AddOrModernizeJenkinsFile,AddDependencyCheck --debug` produced the following PR: https://github.com/jenkinsci/vagrant-plugin/pull/13.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
